### PR TITLE
feat: Seed quiz questions for the 'mile-2026' event and update frontend navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ logs/
 Thumbs.db
 
 /anexus
+.claude/
+.playwright/

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -15,6 +15,31 @@ import (
 	"github.com/the-mile-game/backend/internal/websocket"
 )
 
+// webSocketEventValidator implementa websocket.EventValidator usando EventRepository
+type webSocketEventValidator struct {
+	eventRepo *repository.EventRepository
+}
+
+func (v *webSocketEventValidator) ValidateEvent(slug string) error {
+	event, err := v.eventRepo.GetBySlug(slug)
+	if err != nil {
+		return err
+	}
+	// Verificar que el evento esté activo
+	if !event.IsActive {
+		return &eventInactiveError{slug: slug}
+	}
+	return nil
+}
+
+type eventInactiveError struct {
+	slug string
+}
+
+func (e *eventInactiveError) Error() string {
+	return "event is inactive"
+}
+
 func main() {
 	// Cargar variables de entorno
 	if err := godotenv.Load(); err != nil {
@@ -45,6 +70,7 @@ func main() {
 	postcardRepo := repository.NewPostcardRepository(db, uploadPath)
 	userRepo := repository.NewUserRepository(db)
 	eventRepo := repository.NewEventRepository(db)
+	quizQuestionRepo := repository.NewQuizQuestionRepository(db)
 
 	// Crear servicios
 	jwtSecret := os.Getenv("JWT_SECRET")
@@ -57,8 +83,11 @@ func main() {
 	}
 	authService := services.NewAuthService(userRepo, jwtSecret)
 
-	// Crear WebSocket Hub
-	hub := websocket.NewHub()
+	// WebSocket event validator - valida que el evento existe y está activo
+	eventValidator := &webSocketEventValidator{eventRepo: eventRepo}
+
+	// Crear WebSocket Hub con validador de eventos
+	hub := websocket.NewHubWithValidator(eventValidator)
 	go hub.Run()
 
 	// Crear handlers
@@ -66,7 +95,7 @@ func main() {
 	if uploadsDir == "" {
 		uploadsDir = uploadPath + "/postcards"
 	}
-	handler := handlers.NewHandler(playerRepo, quizRepo, postcardRepo, hub, uploadsDir)
+	handler := handlers.NewHandler(playerRepo, quizRepo, quizQuestionRepo, postcardRepo, hub, uploadsDir)
 	authHandler := handlers.NewAuthHandler(authService)
 
 	// Configurar router
@@ -107,6 +136,7 @@ func main() {
 		auth.Use(authMiddleware)
 		{
 			auth.GET("/me", authHandler.Me)
+			auth.POST("/logout", authHandler.Logout)
 		}
 
 		// Event-scoped routes (nuevas - multi-event)
@@ -127,10 +157,7 @@ func main() {
 			quiz := events.Group("/quiz")
 			quiz.Use(middleware.QuizFeatureMiddleware())
 			{
-				quiz.GET("/questions", func(c *gin.Context) {
-					// TODO: Implementar quiz questions endpoint
-					c.JSON(200, gin.H{"questions": []interface{}{}})
-				})
+				quiz.GET("/questions", handler.GetQuizQuestions)
 				quiz.POST("/submit", handler.SubmitQuiz)
 				quiz.GET("/answers/:playerId", handler.GetQuizAnswers)
 			}

--- a/backend/internal/handlers/auth_handlers.go
+++ b/backend/internal/handlers/auth_handlers.go
@@ -101,3 +101,20 @@ func (h *AuthHandler) Me(c *gin.Context) {
 		"email":   email,
 	})
 }
+
+// Logout cierra la sesión del usuario autenticado
+// POST /api/auth/logout
+// Nota: Dado que usamos JWT stateless sin blacklist, este endpoint
+// hace logout del lado del cliente. El servidor simplemente confirma.
+func (h *AuthHandler) Logout(c *gin.Context) {
+	// Verificar que el usuario está autenticado (middleware ya validó el token)
+	_, exists := c.Get("user_id")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	// Logout stateless: el cliente debe eliminar los tokens
+	// El servidor solo confirma el logout
+	c.JSON(http.StatusOK, gin.H{"message": "Successfully logged out"})
+}

--- a/backend/internal/handlers/auth_handlers_test.go
+++ b/backend/internal/handlers/auth_handlers_test.go
@@ -644,7 +644,7 @@ func TestAuthFlowComplete(t *testing.T) {
 				ExpiresIn:    900,
 				User: models.User{
 					ID:    userID,
-					Email: email,
+					Email: "user@example.com",
 					Name:  "Test User",
 				},
 			}, nil
@@ -809,4 +809,112 @@ func TestAuthFlowComplete(t *testing.T) {
 	}
 
 	t.Log("✅ Complete auth flow test passed!")
+}
+
+// ========== TESTS PARA LOGOUT ==========
+
+func TestLogoutSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	mockAuth := &MockAuthService{
+		ValidateTokenFunc: func(token string) (*models.JWTClaims, error) {
+			if token == "valid-token" {
+				return &models.JWTClaims{
+					UserID: uuid.New(),
+					Email:  "user@example.com",
+				}, nil
+			}
+			return nil, repository.ErrUserNotFound
+		},
+	}
+
+	// Auth middleware
+	authMiddleware := func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing authorization header"})
+			c.Abort()
+			return
+		}
+
+		if len(token) > 7 && token[:7] == "Bearer " {
+			token = token[7:]
+		}
+
+		claims, err := mockAuth.ValidateToken(token)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			c.Abort()
+			return
+		}
+
+		c.Set("user_id", claims.UserID)
+		c.Set("email", claims.Email)
+		c.Next()
+	}
+
+	// Logout handler (simula el handler real)
+	r.POST("/api/auth/logout", authMiddleware, func(c *gin.Context) {
+		_, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "Successfully logged out"})
+	})
+
+	// Test con token válido
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp["message"] != "Successfully logged out" {
+		t.Errorf("Expected message 'Successfully logged out', got '%s'", resp["message"])
+	}
+}
+
+func TestLogoutUnauthenticated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	// Auth middleware
+	authMiddleware := func(c *gin.Context) {
+		token := c.GetHeader("Authorization")
+		if token == "" {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing authorization header"})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+
+	// Logout handler
+	r.POST("/api/auth/logout", authMiddleware, func(c *gin.Context) {
+		_, exists := c.Get("user_id")
+		if !exists {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"message": "Successfully logged out"})
+	})
+
+	// Test sin token
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/auth/logout", nil)
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
 }

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -45,23 +45,25 @@ type BroadcastHub interface {
 
 // Handler maneja las peticiones HTTP
 type Handler struct {
-	playerRepo   *repository.PlayerRepository
-	quizRepo     *repository.QuizRepository
-	postcardRepo PostcardRepo
-	scorer       *services.Scorer
-	hub          BroadcastHub
-	uploadsDir   string
+	playerRepo       *repository.PlayerRepository
+	quizRepo         *repository.QuizRepository
+	quizQuestionRepo *repository.QuizQuestionRepository
+	postcardRepo     PostcardRepo
+	scorer           *services.Scorer
+	hub              BroadcastHub
+	uploadsDir       string
 }
 
 // NewHandler crea un nuevo handler
-func NewHandler(playerRepo *repository.PlayerRepository, quizRepo *repository.QuizRepository, postcardRepo *repository.PostcardRepository, hub *websocket.Hub, uploadsDir string) *Handler {
+func NewHandler(playerRepo *repository.PlayerRepository, quizRepo *repository.QuizRepository, quizQuestionRepo *repository.QuizQuestionRepository, postcardRepo *repository.PostcardRepository, hub *websocket.Hub, uploadsDir string) *Handler {
 	return &Handler{
-		playerRepo:   playerRepo,
-		quizRepo:     quizRepo,
-		postcardRepo: postcardRepo,
-		scorer:       services.NewScorer(),
-		hub:          hub,
-		uploadsDir:   uploadsDir,
+		playerRepo:       playerRepo,
+		quizRepo:         quizRepo,
+		quizQuestionRepo: quizQuestionRepo,
+		postcardRepo:     postcardRepo,
+		scorer:           services.NewScorer(),
+		hub:              hub,
+		uploadsDir:       uploadsDir,
 	}
 }
 
@@ -185,13 +187,15 @@ func (h *Handler) SubmitQuiz(c *gin.Context) {
 	}
 
 	// Cross-event player validation: ensure player belongs to this event
-	if eventID, exists := c.Get("event_id"); exists {
+	var eventID uuid.UUID
+	if eID, exists := c.Get("event_id"); exists {
+		eventID = eID.(uuid.UUID)
 		player, playerErr := h.playerRepo.GetByID(playerID)
 		if playerErr != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "Player not found"})
 			return
 		}
-		if player.EventID != eventID.(uuid.UUID) {
+		if player.EventID != eventID {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Player does not belong to this event"})
 			return
 		}
@@ -215,8 +219,21 @@ func (h *Handler) SubmitQuiz(c *gin.Context) {
 		return
 	}
 
+	// Calcular puntaje - intentar usar preguntas de DB primero, luego fallback a legacy
+	var score int
+	scorer := h.scorer
+
+	// Si hay event_id, intentar cargar preguntas de la DB
+	if eventID != uuid.Nil && h.quizQuestionRepo != nil {
+		questions, qErr := h.quizQuestionRepo.ListByEvent(eventID)
+		if qErr == nil && len(questions) > 0 {
+			// Usar scorer con preguntas de DB
+			scorer = services.NewScorerWithQuestions(questions)
+		}
+	}
+
 	// Calcular puntaje usando las respuestas YA NORMALIZADAS
-	score := h.scorer.Calculate(normalizedFavorites, normalizedPreferences)
+	score = scorer.Calculate(normalizedFavorites, normalizedPreferences)
 
 	// Actualizar puntaje del jugador
 	if err := h.playerRepo.UpdateScore(playerID, score); err != nil {
@@ -227,8 +244,8 @@ func (h *Handler) SubmitQuiz(c *gin.Context) {
 	// Obtener ranking actualizado y broadcastear por WebSocket
 	// Si hay event_id en el contexto, usar ListByEvent, sino List
 	var players []models.Player
-	if eventID, exists := c.Get("event_id"); exists {
-		players, err = h.playerRepo.ListByEvent(eventID.(uuid.UUID))
+	if eventID != uuid.Nil {
+		players, err = h.playerRepo.ListByEvent(eventID)
 	} else {
 		players, err = h.playerRepo.List()
 	}
@@ -270,6 +287,65 @@ func (h *Handler) GetQuizAnswers(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, answers)
+}
+
+// QuizQuestionResponse representa una pregunta del quiz para la API (sin correct_answers)
+type QuizQuestionResponse struct {
+	ID           uuid.UUID `json:"id"`
+	Section      string    `json:"section"`
+	Key          string    `json:"key"`
+	QuestionText string    `json:"question_text"`
+	Options      []string  `json:"options,omitempty"`
+	SortOrder    int       `json:"sort_order"`
+	IsScorable   bool      `json:"is_scorable"`
+}
+
+// GetQuizQuestions obtiene las preguntas del quiz para el evento actual.
+// NO retorna correct_answers para evitar hacer trampa.
+func (h *Handler) GetQuizQuestions(c *gin.Context) {
+	// Obtener event_id del contexto
+	eventID, exists := c.Get("event_id")
+	if !exists {
+		// Si no hay evento en contexto, intentar obtener preguntas legacy (sin evento)
+		// Esto es para backward compatibility con el endpoint legacy /api/quiz/questions
+		questions, err := h.quizQuestionRepo.ListByEvent(uuid.Nil)
+		if err != nil || len(questions) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "No quiz questions found"})
+			return
+		}
+		h.returnQuestionsResponse(questions, c)
+		return
+	}
+
+	questions, err := h.quizQuestionRepo.ListByEvent(eventID.(uuid.UUID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get quiz questions"})
+		return
+	}
+
+	if len(questions) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No quiz questions found for this event"})
+		return
+	}
+
+	h.returnQuestionsResponse(questions, c)
+}
+
+// returnQuestionsResponse helper para devolver preguntas sin correct_answers
+func (h *Handler) returnQuestionsResponse(questions []models.QuizQuestion, c *gin.Context) {
+	response := make([]QuizQuestionResponse, len(questions))
+	for i, q := range questions {
+		response[i] = QuizQuestionResponse{
+			ID:           q.ID,
+			Section:      q.Section,
+			Key:          q.Key,
+			QuestionText: q.QuestionText,
+			Options:      q.Options,
+			SortOrder:    q.SortOrder,
+			IsScorable:   q.IsScorable,
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"questions": response})
 }
 
 // GetRanking obtiene el ranking de jugadores

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -539,3 +539,107 @@ func TestGetPlayerValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestGetQuizQuestions tests the GetQuizQuestions handler returns questions without correct_answers
+func TestGetQuizQuestions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// Create a mock QuizQuestionRepository
+	mockQuestions := []models.QuizQuestion{
+		{
+			ID:             uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			EventID:        uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			Section:        "favorites",
+			Key:            "singer",
+			QuestionText:   "¿Cantante favorito?",
+			CorrectAnswers: []string{"ricardo arjona"}, // Should NOT be exposed
+			Options:        nil,
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+			EventID:        uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			Section:        "preferences",
+			Key:            "coffee",
+			QuestionText:   "¿Café o Té?",
+			CorrectAnswers: []string{"te"}, // Should NOT be exposed
+			Options:        []string{"Café", "Té"},
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+			EventID:        uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+			Section:        "description",
+			Key:            "describe_me",
+			QuestionText:   "¿Descríbeme en una oración?",
+			CorrectAnswers: []string{},
+			Options:        nil,
+			SortOrder:      1,
+			IsScorable:     false,
+		},
+	}
+
+	// Create handler with mock repo
+	r := gin.New()
+
+	// Simulate the GetQuizQuestions handler behavior
+	r.GET("/api/events/:slug/quiz/questions", func(c *gin.Context) {
+		// Simulate event_id in context
+		eventID := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		c.Set("event_id", eventID)
+
+		// Simulate returning questions without correct_answers
+		response := make([]QuizQuestionResponse, len(mockQuestions))
+		for i, q := range mockQuestions {
+			response[i] = QuizQuestionResponse{
+				ID:           q.ID,
+				Section:      q.Section,
+				Key:          q.Key,
+				QuestionText: q.QuestionText,
+				Options:      q.Options,
+				SortOrder:    q.SortOrder,
+				IsScorable:   q.IsScorable,
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"questions": response})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/events/mile-2026/quiz/questions", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+
+	var response map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &response)
+
+	questions := response["questions"].([]interface{})
+	if len(questions) != 3 {
+		t.Errorf("Expected 3 questions, got %d", len(questions))
+	}
+
+	// Verify correct_answers is NOT exposed
+	firstQuestion := questions[0].(map[string]interface{})
+	if _, hasCorrectAnswers := firstQuestion["correct_answers"]; hasCorrectAnswers {
+		t.Error("correct_answers should NOT be exposed in API response")
+	}
+
+	// Verify other fields are present
+	if firstQuestion["key"] != "singer" {
+		t.Errorf("Expected key 'singer', got %v", firstQuestion["key"])
+	}
+	if firstQuestion["question_text"] != "¿Cantante favorito?" {
+		t.Errorf("Expected question_text, got %v", firstQuestion["question_text"])
+	}
+
+	// Verify preferences have options
+	secondQuestion := questions[1].(map[string]interface{})
+	options := secondQuestion["options"].([]interface{})
+	if len(options) != 2 {
+		t.Errorf("Expected 2 options for coffee question, got %d", len(options))
+	}
+}

--- a/backend/internal/services/scorer.go
+++ b/backend/internal/services/scorer.go
@@ -1,5 +1,9 @@
 package services
 
+import (
+	"github.com/the-mile-game/backend/internal/models"
+)
+
 // Scorer calcula el puntaje del quiz usando normalización de texto
 type Scorer struct {
 	normalizer         *Normalizer
@@ -7,7 +11,7 @@ type Scorer struct {
 	correctPreferences map[string]string   // Respuestas YA NORMALIZADAS
 }
 
-// NewScorer crea un nuevo calculador de puntajes
+// NewScorer crea un nuevo calculador de puntajes (modo legacy - hardcoded)
 func NewScorer() *Scorer {
 	normalizer := NewNormalizer()
 
@@ -52,6 +56,41 @@ func NewScorer() *Scorer {
 		normalizer:         normalizer,
 		correctFavorites:   normalizedFavorites,
 		correctPreferences: normalizedPreferences,
+	}
+}
+
+// NewScorerWithQuestions crea un scorer con preguntas de la base de datos.
+// Las preguntas deben tener sus correct_answers ya normalizados (el repo los deserializa).
+func NewScorerWithQuestions(questions []models.QuizQuestion) *Scorer {
+	normalizer := NewNormalizer()
+
+	correctFavorites := make(map[string][]string)
+	correctPreferences := make(map[string]string)
+
+	for _, q := range questions {
+		if !q.IsScorable {
+			continue
+		}
+
+		// Las respuestas ya vienen normalizadas desde la DB
+		correctAnswers := q.CorrectAnswers
+		if len(correctAnswers) == 0 {
+			continue
+		}
+
+		if q.Section == "favorites" {
+			// Favoritos pueden tener múltiples respuestas válidas
+			correctFavorites[q.Key] = correctAnswers
+		} else if q.Section == "preferences" {
+			// Preferencias tienen una sola respuesta correcta
+			correctPreferences[q.Key] = correctAnswers[0]
+		}
+	}
+
+	return &Scorer{
+		normalizer:         normalizer,
+		correctFavorites:   correctFavorites,
+		correctPreferences: correctPreferences,
 	}
 }
 

--- a/backend/internal/services/scorer_test.go
+++ b/backend/internal/services/scorer_test.go
@@ -2,6 +2,9 @@ package services
 
 import (
 	"testing"
+
+	"github.com/google/uuid"
+	"github.com/the-mile-game/backend/internal/models"
 )
 
 func TestNewScorer(t *testing.T) {
@@ -285,5 +288,248 @@ func TestDislikeAcceptsAllValidAnswers(t *testing.T) {
 				t.Errorf("dislike=%q should give perfect score 13, got %d", dislike, score)
 			}
 		})
+	}
+}
+
+func TestNewScorerWithQuestions(t *testing.T) {
+	// Crear preguntas en formato DB (ya normalizadas)
+	questions := []models.QuizQuestion{
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "singer",
+			QuestionText:   "¿Cantante favorito?",
+			CorrectAnswers: []string{"ricardo arjona"},
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "flower",
+			QuestionText:   "¿Flor favorita?",
+			CorrectAnswers: []string{"girasol"},
+			SortOrder:      2,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "dislike",
+			QuestionText:   "¿Algo que no le guste?",
+			CorrectAnswers: []string{"aranas", "madrugar", "sol"}, // Multiple valid answers
+			SortOrder:      7,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "preferences",
+			Key:            "coffee",
+			QuestionText:   "¿Café o Té?",
+			CorrectAnswers: []string{"te"},
+			Options:        []string{"Café", "Té"},
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "preferences",
+			Key:            "place",
+			QuestionText:   "¿Playa o Montaña?",
+			CorrectAnswers: []string{"playa"},
+			Options:        []string{"Playa", "Montaña"},
+			SortOrder:      2,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "description",
+			Key:            "describe_me",
+			QuestionText:   "¿Descríbeme en una oración?",
+			CorrectAnswers: []string{},
+			SortOrder:      1,
+			IsScorable:     false, // Not scorable
+		},
+	}
+
+	s := NewScorerWithQuestions(questions)
+
+	if s == nil {
+		t.Error("NewScorerWithQuestions() returned nil")
+	}
+	if s.normalizer == nil {
+		t.Error("Scorer should have a normalizer")
+	}
+
+	// Verificar que cargó las preguntas de favoritos
+	if len(s.correctFavorites) != 3 {
+		t.Errorf("Scorer should have 3 favorite questions, got %d", len(s.correctFavorites))
+	}
+
+	// Verificar que dislike tiene las 3 respuestas válidas
+	if len(s.correctFavorites["dislike"]) != 3 {
+		t.Errorf("dislike should have 3 valid answers, got %d", len(s.correctFavorites["dislike"]))
+	}
+
+	// Verificar que cargó las preguntas de preferencias
+	if len(s.correctPreferences) != 2 {
+		t.Errorf("Scorer should have 2 preference questions, got %d", len(s.correctPreferences))
+	}
+}
+
+func TestScorerWithDBQuestions_Calculate(t *testing.T) {
+	// Crear preguntas en formato DB (ya normalizadas)
+	questions := []models.QuizQuestion{
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "singer",
+			QuestionText:   "¿Cantante favorito?",
+			CorrectAnswers: []string{"ricardo arjona"},
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "flower",
+			QuestionText:   "¿Flor favorita?",
+			CorrectAnswers: []string{"girasol"},
+			SortOrder:      2,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "favorites",
+			Key:            "dislike",
+			QuestionText:   "¿Algo que no le guste?",
+			CorrectAnswers: []string{"aranas", "madrugar", "sol"},
+			SortOrder:      7,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "preferences",
+			Key:            "coffee",
+			QuestionText:   "¿Café o Té?",
+			CorrectAnswers: []string{"te"},
+			Options:        []string{"Café", "Té"},
+			SortOrder:      1,
+			IsScorable:     true,
+		},
+		{
+			ID:             uuid.New(),
+			EventID:        uuid.Nil,
+			Section:        "preferences",
+			Key:            "place",
+			QuestionText:   "¿Playa o Montaña?",
+			CorrectAnswers: []string{"playa"},
+			Options:        []string{"Playa", "Montaña"},
+			SortOrder:      2,
+			IsScorable:     true,
+		},
+	}
+
+	s := NewScorerWithQuestions(questions)
+
+	tests := []struct {
+		name        string
+		favorites   map[string]string
+		preferences map[string]string
+		expected    int
+	}{
+		{
+			name: "perfect score",
+			favorites: map[string]string{
+				"singer":  "ricardo arjona",
+				"flower":  "girasol",
+				"dislike": "aranas",
+			},
+			preferences: map[string]string{
+				"coffee": "te",
+				"place":  "playa",
+			},
+			expected: 5,
+		},
+		{
+			name: "dislike accepts madrugar",
+			favorites: map[string]string{
+				"singer":  "ricardo arjona",
+				"flower":  "girasol",
+				"dislike": "madrugar",
+			},
+			preferences: map[string]string{
+				"coffee": "te",
+				"place":  "playa",
+			},
+			expected: 5,
+		},
+		{
+			name: "all wrong",
+			favorites: map[string]string{
+				"singer":  "shakira",
+				"flower":  "rosa",
+				"dislike": "nadar",
+			},
+			preferences: map[string]string{
+				"coffee": "cafe",
+				"place":  "montana",
+			},
+			expected: 0,
+		},
+		{
+			name:        "empty answers",
+			favorites:   map[string]string{},
+			preferences: map[string]string{},
+			expected:    0,
+		},
+		{
+			name: "partial score",
+			favorites: map[string]string{
+				"singer": "ricardo arjona", // correct
+				"flower": "rosa",           // wrong
+			},
+			preferences: map[string]string{
+				"coffee": "cafe",  // wrong
+				"place":  "playa", // correct
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := s.Calculate(tt.favorites, tt.preferences)
+			if score != tt.expected {
+				t.Errorf("Calculate() = %d, want %d", score, tt.expected)
+			}
+		})
+	}
+}
+
+func TestScorerWithQuestions_EmptyQuestions(t *testing.T) {
+	s := NewScorerWithQuestions([]models.QuizQuestion{})
+
+	if s == nil {
+		t.Error("NewScorerWithQuestions() returned nil")
+	}
+
+	// Should handle empty questions gracefully
+	score := s.Calculate(
+		map[string]string{"singer": "ricardo arjona"},
+		map[string]string{"coffee": "te"},
+	)
+	if score != 0 {
+		t.Errorf("Expected 0 score with no questions, got %d", score)
 	}
 }

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -46,8 +46,16 @@ type Hub struct {
 	// Canal para broadcastear a un evento específico
 	broadcastToRoom chan *RoomMessage
 
+	// Validador de eventos (opcional) - si está presente, se validan los event slugs
+	eventValidator EventValidator
+
 	// Mutex para acceso seguro concurrente
 	mu sync.RWMutex
+}
+
+// EventValidator interface para validar que un evento existe y está activo
+type EventValidator interface {
+	ValidateEvent(slug string) error
 }
 
 // RoomMessage mensaje dirigido a un room específico
@@ -98,7 +106,7 @@ var upgrader = websocket.Upgrader{
 	},
 }
 
-// NewHub crea un nuevo Hub
+// NewHub crea un nuevo Hub sin validador de eventos
 func NewHub() *Hub {
 	return &Hub{
 		register:        make(chan *Client),
@@ -108,6 +116,13 @@ func NewHub() *Hub {
 		clients:         make(map[*Client]bool),
 		rooms:           make(map[string]map[*Client]bool),
 	}
+}
+
+// NewHubWithValidator crea un nuevo Hub con validador de eventos
+func NewHubWithValidator(validator EventValidator) *Hub {
+	hub := NewHub()
+	hub.eventValidator = validator
+	return hub
 }
 
 // Run inicia el loop del hub para manejar registros y broadcasts
@@ -209,12 +224,21 @@ func (h *Hub) Run() {
 
 // ServeHTTP maneja las conexiones WebSocket
 // El query param "event" es opcional; sin él el cliente recibe broadcasts globales
+// Si hay un eventValidator configurado, se validará que el evento exista
 func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Extraer event slug del query param
 	eventSlug := r.URL.Query().Get("event")
 	if eventSlug == "" {
 		// Sin event, el cliente no recibe mensajes específicos
 		log.Printf("WebSocket: Conexión sin event slug - recibirá broadcasts globales nomás")
+	} else if h.eventValidator != nil {
+		// Validar que el evento existe y está activo
+		if err := h.eventValidator.ValidateEvent(eventSlug); err != nil {
+			log.Printf("WebSocket: Evento '%s' no válido: %v", eventSlug, err)
+			http.Error(w, "Event not found or inactive", http.StatusNotFound)
+			return
+		}
+		log.Printf("WebSocket: Conexión al evento '%s' aceptada", eventSlug)
 	}
 
 	conn, err := upgrader.Upgrade(w, r, nil)

--- a/backend/internal/websocket/hub_test.go
+++ b/backend/internal/websocket/hub_test.go
@@ -1,0 +1,517 @@
+package websocket
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/the-mile-game/backend/internal/models"
+)
+
+// mockConn es un mock de websocket.Conn para testing
+type mockConn struct {
+	writeMsgChan chan []byte
+	readMsgChan  chan []byte
+	closeCalled  bool
+}
+
+func newMockConn() *mockConn {
+	return &mockConn{
+		writeMsgChan: make(chan []byte, 256),
+		readMsgChan:  make(chan []byte, 256),
+	}
+}
+
+func (m *mockConn) ReadMessage() (int, []byte, error) {
+	msg, ok := <-m.readMsgChan
+	if !ok {
+		return 0, nil, errors.New("connection closed")
+	}
+	return websocket.TextMessage, msg, nil
+}
+
+func (m *mockConn) WriteMessage(t int, data []byte) error {
+	m.writeMsgChan <- data
+	return nil
+}
+
+func (m *mockConn) Close() error {
+	m.closeCalled = true
+	return nil
+}
+
+func (m *mockConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetPongHandler(h func(string) error) {
+}
+
+func (m *mockConn) SetPingHandler(h func(string) error) {
+}
+
+func (m *mockConn) LocalAddr() string {
+	return "localhost:8080"
+}
+
+func (m *mockConn) RemoteAddr() string {
+	return "localhost:12345"
+}
+
+// mockEventValidator es un validador simple para tests
+type mockEventValidator struct {
+	validEvents map[string]bool
+}
+
+func newMockEventValidator() *mockEventValidator {
+	return &mockEventValidator{
+		validEvents: map[string]bool{
+			"mile-cumple": true,
+			"test-event":  true,
+		},
+	}
+}
+
+func (m *mockEventValidator) ValidateEvent(slug string) error {
+	if !m.validEvents[slug] {
+		return ErrEventNotFound
+	}
+	return nil
+}
+
+// ErrEventNotFound es el error cuando el evento no existe
+var ErrEventNotFound = &eventNotFoundError{}
+
+type eventNotFoundError struct{}
+
+func (e *eventNotFoundError) Error() string {
+	return "event not found"
+}
+
+func TestHub_RegisterClient(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear cliente mock
+	client := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "mile-cumple",
+	}
+
+	// Registrar cliente
+	hub.register <- client
+
+	// Esperar a que se registre
+	time.Sleep(50 * time.Millisecond)
+
+	// Verificar que el cliente está en el room correcto
+	hub.mu.RLock()
+	roomClients := hub.rooms["mile-cumple"]
+	hub.mu.RUnlock()
+
+	if roomClients == nil {
+		t.Fatal("Room 'mile-cumple' should exist")
+	}
+
+	if !roomClients[client] {
+		t.Error("Client should be in room 'mile-cumple'")
+	}
+
+	// Verificar que también está en clients global
+	hub.mu.RLock()
+	_, exists := hub.clients[client]
+	hub.mu.RUnlock()
+
+	if !exists {
+		t.Error("Client should be in global clients map")
+	}
+}
+
+func TestHub_BroadcastToEvent(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear cliente mock que escucha el evento "mile-cumple"
+	client1 := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "mile-cumple",
+	}
+
+	hub.register <- client1
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast ranking solo a "mile-cumple"
+	ranking := []models.RankingEntry{
+		{
+			Position: 1,
+			Player: models.Player{
+				ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:   "Player1",
+				Avatar: "👤",
+				Score:  10,
+			},
+		},
+	}
+
+	hub.BroadcastRankingToRoom("mile-cumple", ranking)
+
+	// Verificar que el cliente recibió el mensaje
+	select {
+	case msg := <-client1.send:
+		var wsMsg Message
+		if err := json.Unmarshal(msg, &wsMsg); err != nil {
+			t.Errorf("Failed to unmarshal message: %v", err)
+		}
+		if wsMsg.Type != "ranking_update" {
+			t.Errorf("Expected ranking_update, got %s", wsMsg.Type)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Client should receive message within timeout")
+	}
+}
+
+func TestHub_BroadcastIsolation(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear dos clientes en diferentes eventos
+	clientA := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "event-a",
+	}
+
+	clientB := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "event-b",
+	}
+
+	hub.register <- clientA
+	hub.register <- clientB
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast ranking solo a "event-a"
+	ranking := []models.RankingEntry{
+		{
+			Position: 1,
+			Player: models.Player{
+				ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:   "PlayerA",
+				Avatar: "👤",
+				Score:  10,
+			},
+		},
+	}
+
+	hub.BroadcastRankingToRoom("event-a", ranking)
+
+	// Verificar que SOLO clientA recibió el mensaje
+	select {
+	case msg := <-clientA.send:
+		var wsMsg Message
+		if err := json.Unmarshal(msg, &wsMsg); err != nil {
+			t.Errorf("Failed to unmarshal message: %v", err)
+		}
+		if wsMsg.Type != "ranking_update" {
+			t.Errorf("Expected ranking_update, got %s", wsMsg.Type)
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Client A should receive message within timeout")
+	}
+
+	// Verificar que clientB NO recibió nada (el canal debe estar vacío)
+	select {
+	case msg := <-clientB.send:
+		t.Errorf("Client B should NOT receive message from event-a, got: %s", string(msg))
+	default:
+		// Canal vacío, esperado - cliente B no debe recibir mensajes de event-a
+	}
+}
+
+func TestHub_UnregisterClient(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear cliente
+	client := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "mile-cumple",
+	}
+
+	hub.register <- client
+	time.Sleep(50 * time.Millisecond)
+
+	// Verificar que está registrado
+	hub.mu.RLock()
+	roomClients := hub.rooms["mile-cumple"]
+	hub.mu.RUnlock()
+
+	if roomClients == nil || len(roomClients) != 1 {
+		t.Fatalf("Client should be in room, got %v", roomClients)
+	}
+
+	// Desregistrar
+	hub.unregister <- client
+	time.Sleep(50 * time.Millisecond)
+
+	// Verificar que fue removido
+	hub.mu.RLock()
+	roomClients = hub.rooms["mile-cumple"]
+	hub.mu.RUnlock()
+
+	if roomClients != nil && len(roomClients) > 0 {
+		t.Error("Client should be removed from room")
+	}
+}
+
+func TestHub_EmptyRoomCleanup(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear y registrar cliente
+	client := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "temp-event",
+	}
+
+	hub.register <- client
+	time.Sleep(50 * time.Millisecond)
+
+	// Desregistrar
+	hub.unregister <- client
+	time.Sleep(50 * time.Millisecond)
+
+	// Verificar que el room fue limpiado
+	hub.mu.RLock()
+	room := hub.rooms["temp-event"]
+	hub.mu.RUnlock()
+
+	// El room puede seguir existiendo como mapa vacío o haber sido eliminado
+	// Ambas son aceptables - verificamos que el cliente no esté
+	if room != nil && len(room) > 0 {
+		t.Error("Room should be empty or removed")
+	}
+}
+
+func TestHub_BroadcastToAll(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear clientes en diferentes rooms
+	clientA := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "event-a",
+	}
+
+	clientB := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "event-b",
+	}
+
+	clientNoRoom := &Client{
+		hub:       hub,
+		conn:      &websocket.Conn{},
+		send:      make(chan []byte, 256),
+		EventSlug: "",
+	}
+
+	hub.register <- clientA
+	hub.register <- clientB
+	hub.register <- clientNoRoom
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast global (sin room)
+	ranking := []models.RankingEntry{
+		{
+			Position: 1,
+			Player: models.Player{
+				ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:   "Player1",
+				Avatar: "👤",
+				Score:  10,
+			},
+		},
+	}
+
+	hub.BroadcastRanking(ranking)
+
+	// Verificar que todos recibieron el mensaje
+	for _, client := range []*Client{clientA, clientB, clientNoRoom} {
+		select {
+		case msg := <-client.send:
+			var wsMsg Message
+			if err := json.Unmarshal(msg, &wsMsg); err != nil {
+				t.Errorf("Failed to unmarshal message: %v", err)
+			}
+			if wsMsg.Type != "ranking_update" {
+				t.Errorf("Expected ranking_update, got %s", wsMsg.Type)
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("All clients should receive global broadcast")
+		}
+	}
+}
+
+func TestHub_MultipleClientsSameRoom(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Crear múltiples clientes en el mismo room
+	var clients []*Client
+	for i := 0; i < 3; i++ {
+		client := &Client{
+			hub:       hub,
+			conn:      &websocket.Conn{},
+			send:      make(chan []byte, 256),
+			EventSlug: "mile-cumple",
+		}
+		clients = append(clients, client)
+		hub.register <- client
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast al room
+	ranking := []models.RankingEntry{
+		{
+			Position: 1,
+			Player: models.Player{
+				ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:   "Player1",
+				Avatar: "👤",
+				Score:  10,
+			},
+		},
+	}
+
+	hub.BroadcastRankingToRoom("mile-cumple", ranking)
+
+	// Verificar que TODOS los clientes recibieron el mensaje
+	for i, client := range clients {
+		select {
+		case msg := <-client.send:
+			var wsMsg Message
+			if err := json.Unmarshal(msg, &wsMsg); err != nil {
+				t.Errorf("Client %d: Failed to unmarshal message: %v", i, err)
+			}
+			if wsMsg.Type != "ranking_update" {
+				t.Errorf("Client %d: Expected ranking_update, got %s", i, wsMsg.Type)
+			}
+		case <-time.After(1 * time.Second):
+			t.Errorf("Client %d should receive message within timeout", i)
+		}
+	}
+}
+
+func TestHub_ConcurrentRegister(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Registrar muchos clientes concurrentemente
+	var wg sync.WaitGroup
+	numClients := 100
+
+	for i := 0; i < numClients; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			client := &Client{
+				hub:       hub,
+				conn:      &websocket.Conn{},
+				send:      make(chan []byte, 256),
+				EventSlug: "test-event",
+			}
+			hub.register <- client
+		}(i)
+	}
+
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+
+	// Verificar que todos están registrados
+	hub.mu.RLock()
+	roomClients := hub.rooms["test-event"]
+	totalClients := len(hub.clients)
+	hub.mu.RUnlock()
+
+	if len(roomClients) != numClients {
+		t.Errorf("Expected %d clients in room, got %d", numClients, len(roomClients))
+	}
+
+	if totalClients != numClients {
+		t.Errorf("Expected %d total clients, got %d", numClients, totalClients)
+	}
+}
+
+func TestHub_NonExistentRoomBroadcast(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+	defer func() {
+		hub.broadcast <- []byte{} // Signal to stop
+	}()
+
+	// Broadcast a un room que no existe - no debe fallar
+	ranking := []models.RankingEntry{
+		{
+			Position: 1,
+			Player: models.Player{
+				ID:     uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:   "Player1",
+				Avatar: "👤",
+				Score:  10,
+			},
+		},
+	}
+
+	// Esto no debe bloquear ni panicar
+	hub.BroadcastRankingToRoom("non-existent-event", ranking)
+
+	// El broadcast a room inexistente es un no-op, el código debe continuar
+	time.Sleep(50 * time.Millisecond)
+}

--- a/backend/migrations/005_seed_quiz_questions.sql
+++ b/backend/migrations/005_seed_quiz_questions.sql
@@ -1,0 +1,281 @@
+-- Migration: 005_seed_quiz_questions.sql
+-- Seed quiz questions for the legacy event 'mile-2026'
+-- 
+-- This migration populates the quiz_questions table with all questions
+-- from the hardcoded scorer.go for the legacy event.
+--
+-- IMPORTANT: This migration is IDEMPOTENT - uses ON CONFLICT DO NOTHING
+-- to prevent duplicates if run multiple times.
+
+-- ============================================
+-- SEED QUIZ QUESTIONS FOR mile-2026 EVENT
+-- ============================================
+
+DO $$
+DECLARE
+    legacy_event_id UUID;
+BEGIN
+    -- Get the event ID for 'mile-2026'
+    SELECT id INTO legacy_event_id FROM events WHERE slug = 'mile-2026';
+    
+    -- If event doesn't exist, raise notice (idempotent behavior)
+    IF legacy_event_id IS NULL THEN
+        RAISE NOTICE 'Event mile-2026 not found, skipping quiz questions seed';
+        RETURN;
+    END IF;
+
+    RAISE NOTICE 'Seeding quiz questions for event: %', legacy_event_id;
+
+    -- ============================================
+    -- SECTION: FAVORITES (7 questions, scorable)
+    -- ============================================
+
+    -- singer: Cantante favorito
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'singer',
+        '¿Cantante favorito?',
+        '["ricardo arjona"]'::jsonb,
+        NULL,
+        1,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- flower: Flor favorita
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'flower',
+        '¿Flor favorita?',
+        '["girasol"]'::jsonb,
+        NULL,
+        2,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- drink: Bebida favorita
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'drink',
+        '¿Cuál es mi bebida favorita?',
+        '["te verde"]'::jsonb,
+        NULL,
+        3,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- disney: Película de Disney favorita
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'disney',
+        '¿Película de Disney favorita?',
+        '["bella y bestia"]'::jsonb,  -- "la bella y la bestia" normalizado (elimina artículos)
+        NULL,
+        4,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- season: Estación del año preferida
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'season',
+        '¿Estación del año preferida?',
+        '["primavera"]'::jsonb,
+        NULL,
+        5,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- color: Color favorito
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'color',
+        '¿Cuál es mi color favorito?',
+        '["rosado"]'::jsonb,
+        NULL,
+        6,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- dislike: Algo que no le guste
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'favorites',
+        'dislike',
+        '¿Menciona algo que no me guste?',
+        '["aranas", "madrugar", "sol"]'::jsonb,  -- Multiple valid answers: "las arañas", "madrugar", "el sol"
+        NULL,
+        7,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- ============================================
+    -- SECTION: PREFERENCES (6 questions, scorable)
+    -- ============================================
+
+    -- coffee: Café o Té?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'coffee',
+        '¿Café o Té?',
+        '["te"]'::jsonb,
+        '["Café", "Té"]'::jsonb,
+        1,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- place: Playa o Montaña?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'place',
+        '¿Playa o Montaña?',
+        '["playa"]'::jsonb,
+        '["Playa", "Montaña"]'::jsonb,
+        2,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- weather: Frío o Calor?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'weather',
+        '¿Frío o Calor?',
+        '["frio"]'::jsonb,  -- "frío" normalizado (elimina acento)
+        '["Frío", "Calor"]'::jsonb,
+        3,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- time: Día o Noche?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'time',
+        '¿Día o Noche?',
+        '["noche"]'::jsonb,
+        '["Día", "Noche"]'::jsonb,
+        4,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- food: Pizza o Sushi?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'food',
+        '¿Pizza o Sushi?',
+        '["sushi"]'::jsonb,
+        '["Pizza", "Sushi"]'::jsonb,
+        5,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- alcohol: Tequila o Vino?
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'preferences',
+        'alcohol',
+        '¿Tequila o Vino?',
+        '["tequila"]'::jsonb,
+        '["Tequila", "Vino"]'::jsonb,
+        6,
+        TRUE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- ============================================
+    -- SECTION: DESCRIPTION (1 question, NOT scorable)
+    -- ============================================
+
+    -- describe_me: Descríbeme en una oración
+    INSERT INTO quiz_questions (id, event_id, section, key, question_text, correct_answers, options, sort_order, is_scorable)
+    VALUES (
+        gen_random_uuid(),
+        legacy_event_id,
+        'description',
+        'describe_me',
+        '¿Descríbeme en una oración?',
+        '[]'::jsonb,  -- No correct answers, not scorable
+        NULL,
+        1,
+        FALSE
+    )
+    ON CONFLICT (event_id, key) DO NOTHING;
+
+    -- ============================================
+    -- VERIFICATION
+    -- ============================================
+    RAISE NOTICE 'Quiz questions seeded successfully for event mile-2026';
+    RAISE NOTICE 'Total questions: 14 (7 favorites + 6 preferences + 1 description)';
+
+END $$;
+
+-- ============================================
+-- NOTES
+-- ============================================
+--
+-- All correct_answers are NORMALIZED according to scorer.go:
+-- - Lowercase
+-- - No accents (á→a, é→e, etc.)
+-- - No punctuation
+-- - Articles removed (el, la, los, las, un, una, etc.)
+--
+-- For preferences, options are stored as JSONB array
+-- matching the frontend options in quiz.constants.ts
+--
+-- The dislike question accepts 3 valid answers:
+-- - "aranas" (from "las arañas")
+-- - "madrugar"
+-- - "sol" (from "el sol")
+--
+-- To apply this migration manually:
+--   docker exec -i milegame-db psql -U user -d milegame < backend/migrations/005_seed_quiz_questions.sql
+--
+-- Or rebuild the postgres container to trigger auto-migration:
+--   docker-compose up -d --force-recreate postgres

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,11 @@
 server {
     listen 80;
     server_name localhost;
+
+    # Disable absolute redirects so 307 redirects use relative paths
+    # This fixes redirect port issue when container is mapped to external port (e.g., 8081)
+    absolute_redirect off;
+
     root /usr/share/nginx/html;
     index index.html;
 

--- a/frontend/playwright.docker.config.ts
+++ b/frontend/playwright.docker.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Docker-specific Playwright config for E2E testing against the Docker nginx.
+ * 
+ * Usage:
+ *   cd frontend && npx playwright test --config=playwright.docker.config.ts --reporter=list
+ * 
+ * Prerequisites:
+ *   - Docker must be running with: docker-compose up -d
+ *   - Frontend built inside Docker (production build)
+ *   - Backend running inside Docker
+ *   - Nginx exposed at localhost:8081
+ * 
+ * Key differences from playwright.config.ts:
+ *   - Uses localhost:8081 (Docker nginx) instead of localhost:5173 (Vite dev server)
+ *   - No webServer (assumes Docker is already running)
+ *   - Routes like /quiz, /ranking, /thank-you are 307-redirected to /event/mile-2026/*
+ */
+export default defineConfig({
+  testDir: './testsprite_tests',
+  
+  // Fail fast in CI, run all in development
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  
+  // Reporter
+  reporter: [['html', { open: 'never' }], ['list']],
+  
+  // Global timeout settings
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+
+  use: {
+    // Docker nginx port (exposed via docker-compose)
+    baseURL: 'http://localhost:8081',
+    trace: 'on-first-retry',
+    // Headless by default; use PWDEBUG=1 to open browser
+    headless: true,
+    // Slow down for debugging: slowMo: 500,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // NO webServer - assumes Docker is already running with:
+  // docker-compose up -d
+  // The nginx at localhost:8081 proxies to backend internally.
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -304,6 +304,15 @@ function AnimatedRoutes() {
             </EventLoader>
           } />
           
+          {/* Register: página de registro dentro del evento */}
+          <Route path="register" element={
+            <EventLoader>
+              <AnimatedPage variants={slideRightVariants}>
+                <RegisterPage />
+              </AnimatedPage>
+            </EventLoader>
+          } />
+          
           {/* Catch-all para rutas inválidas dentro del evento */}
           <Route path="*" element={
             <EventLoader>

--- a/frontend/src/features/postcards/pages/CorkboardPage.tsx
+++ b/frontend/src/features/postcards/pages/CorkboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
+import { useSearchParams } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { usePostcards } from '../hooks/usePostcards';
 import { PostcardCard } from '../components/PostcardCard';
@@ -15,7 +16,7 @@ import type { Postcard } from '../types/postcards.types';
 import corkTexture from '@/assets/cartelera.png';
 
 export function CorkboardPage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const [searchParams] = useSearchParams();
   const {
     postcards,

--- a/frontend/src/features/quiz/hooks/useQuiz.ts
+++ b/frontend/src/features/quiz/hooks/useQuiz.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { useQuizStore } from '../store/quizStore';
 import { quizService } from '../services/quizApi';
 import { TOTAL_QUESTIONS, FAVORITE_QUESTIONS, PREFERENCE_QUESTIONS } from '../types/quiz.constants';
 
 export function useQuiz() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 

--- a/frontend/src/features/quiz/pages/QuizPage.tsx
+++ b/frontend/src/features/quiz/pages/QuizPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { motion } from 'framer-motion';
 import { Button, Input, TextArea, Header, PageLayout, ScrollReveal, ScrollStagger, ScrollStaggerItem } from '@/shared';
 import { useQuiz } from '../hooks/useQuiz';
@@ -51,7 +51,7 @@ function ProgressBarMinimal({ current, total }: { current: number; total: number
 // Preguntas del quiz — definidas en quiz.constants.ts, importadas aquí
 
 export function QuizPage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const [hydrated, setHydrated] = useState(false);
   const {
     answers,

--- a/frontend/src/features/quiz/pages/RegisterPage.tsx
+++ b/frontend/src/features/quiz/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { motion } from 'framer-motion';
 import { Button, Input, Header, PageLayout, Card, ScrollReveal, ScrollStagger, ScrollStaggerItem } from '@/shared';
 import { useQuizStore } from '../store/quizStore';
@@ -58,7 +58,7 @@ const AVATAR_EMOJIS = [
 ];
 
 export function RegisterPage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const [playerName, setPlayerName] = useState('');
   const [selectedAvatar, setSelectedAvatar] = useState('👸');
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);

--- a/frontend/src/features/quiz/pages/ThankYouPage.tsx
+++ b/frontend/src/features/quiz/pages/ThankYouPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { motion } from 'framer-motion';
 import { Button, Header, PageLayout, Card, ScrollReveal, ScrollStagger, ScrollStaggerItem, FEATURES } from '@/shared';
 import { useQuizStore } from '../store/quizStore';
@@ -49,7 +49,7 @@ const scoreVariants = {
 };
 
 export function ThankYouPage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   
   // Datos reales del store
   const playerName = useQuizStore((state) => state.playerName);

--- a/frontend/src/features/quiz/pages/WelcomePage.tsx
+++ b/frontend/src/features/quiz/pages/WelcomePage.tsx
@@ -1,11 +1,38 @@
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
+import { useEventStore } from '@/shared/store/eventStore';
+import { api } from '@/shared/lib/api';
 import { motion } from 'framer-motion';
 import { Button, Header, PageLayout, Card, ScrollReveal, FEATURES } from '@/shared';
 import { useQuizStore } from '../store/quizStore';
 
 export function WelcomePage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const hasCompleted = useQuizStore((s) => s.hasCompleted);
+  const { currentEvent, setEvent } = useEventStore();
+
+  // Load default event on mount so useEventNavigate can prepend the event slug
+  useEffect(() => {
+    if (!currentEvent) {
+      api.getEventBySlug('mile-2026')
+        .then((event) => {
+          // Transform snake_case from API to camelCase for store
+          setEvent({
+            id: event.id,
+            slug: event.slug,
+            name: event.name,
+            description: event.description,
+            date: event.date,
+            ownerId: event.owner_id,
+            features: event.features,
+            isActive: event.is_active,
+          });
+        })
+        .catch((error) => {
+          console.error('Failed to load default event:', error);
+        });
+    }
+  }, [currentEvent, setEvent]);
 
   return (
     <PageLayout background="butterfly-animated" showSparkles={false}>

--- a/frontend/src/features/ranking/pages/RankingPage.tsx
+++ b/frontend/src/features/ranking/pages/RankingPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { motion } from 'framer-motion';
 import { Button, Header, PageLayout, Card, MedalCanvas, RankingSkeleton, FEATURES } from '@/shared';
 import { useRanking } from '../hooks/useRanking';
@@ -32,7 +32,7 @@ const podiumVariants = {
 };
 
 export function RankingPage() {
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const {
     ranking,
     isLoading,

--- a/frontend/src/shared/components/EventLoader.tsx
+++ b/frontend/src/shared/components/EventLoader.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
+import { useEventNavigate } from '@/shared/hooks/useEventNavigate';
 import { useEventStore, type Event } from '@/shared/store/eventStore';
 import { api } from '@/shared/lib/api';
 import { Button } from '@/shared/components/Button';
@@ -11,7 +12,7 @@ interface EventLoaderProps {
 
 export function EventLoader({ children, fallback }: EventLoaderProps) {
   const { slug } = useParams<{ slug: string }>();
-  const navigate = useNavigate();
+  const navigate = useEventNavigate();
   const { currentEvent, setEvent, setLoading, setError, isLoading, error } = useEventStore();
   const [notFound, setNotFound] = useState(false);
 

--- a/frontend/src/shared/hooks/index.ts
+++ b/frontend/src/shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export { usePullToRefresh } from './usePullToRefresh';
+export { useEventNavigate } from './useEventNavigate';

--- a/frontend/src/shared/hooks/useEventNavigate.ts
+++ b/frontend/src/shared/hooks/useEventNavigate.ts
@@ -1,0 +1,44 @@
+import { useNavigate, useParams, type NavigateOptions } from 'react-router-dom';
+import { useEventStore } from '../store/eventStore';
+
+/**
+ * Custom hook that wraps react-router's useNavigate to automatically
+ * prepend the event slug when navigating within an event context.
+ * 
+ * Usage:
+ *   const navigate = useEventNavigate();
+ *   navigate('/register'); // → /event/mile-2026/register (if slug=mile-2026)
+ *   navigate('/event/other/quiz'); // → navigates as-is
+ *   navigate('/'); // → /event/mile-2026 (if in event context)
+ */
+export function useEventNavigate() {
+  const navigate = useNavigate();
+  const params = useParams();
+  const currentEvent = useEventStore((state) => state.currentEvent);
+
+  // Get the event slug from URL params first, then from store
+  const eventSlug = params.slug || currentEvent?.slug;
+
+  return (to: string, options?: NavigateOptions) => {
+    // Only modify paths that:
+    // 1. Start with '/' (absolute paths)
+    // 2. Don't already start with '/event/' (avoid double-prefixing)
+    // 3. We have an event slug available
+    if (to.startsWith('/') && !to.startsWith('/event/') && eventSlug) {
+      // Prepend /event/{slug} to the path
+      // Only pass options if defined to maintain compatibility with tests
+      if (options !== undefined) {
+        navigate(`/event/${eventSlug}${to}`, options);
+      } else {
+        navigate(`/event/${eventSlug}${to}`);
+      }
+    } else {
+      // Navigate as-is (relative paths, /event/ paths, or no event context)
+      if (options !== undefined) {
+        navigate(to, options);
+      } else {
+        navigate(to);
+      }
+    }
+  };
+}

--- a/frontend/src/shared/index.ts
+++ b/frontend/src/shared/index.ts
@@ -39,6 +39,7 @@ export {
   scrollVariants 
 } from './hooks/useScrollAnimation';
 export { usePullToRefresh } from './hooks/usePullToRefresh';
+export { useEventNavigate } from './hooks/useEventNavigate';
 
 // API Client
 export { api } from './lib/api';

--- a/frontend/testsprite_tests/navigation.spec.ts
+++ b/frontend/testsprite_tests/navigation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Navigation Tests', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
   });
 
   test('should navigate from Welcome to Register page', async ({ page }) => {
@@ -12,21 +12,21 @@ test.describe('Navigation Tests', () => {
     // Click the start button
     await page.getByRole('button', { name: /Empezar Juego/i }).click();
     
-    // Verify navigation to register page
-    await expect(page).toHaveURL(/.*register/);
+    // Verify navigation to register page (event-scoped)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
     await expect(page.getByText('Registro')).toBeVisible();
   });
 
   test('should navigate back from Register to Welcome', async ({ page }) => {
     // Navigate to register first
     await page.getByRole('button', { name: /Empezar Juego/i }).click();
-    await expect(page).toHaveURL(/.*register/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
     
     // Click back button
     await page.getByText(/Volver al inicio/i).click();
     
-    // Verify we're back on welcome page
-    await expect(page).toHaveURL('http://localhost:5173/');
+    // Verify we're back on welcome page (root redirects to /event/mile-2026)
+    await expect(page).toHaveURL(/\/event\/mile-2026/);
     await expect(page.getByText('¡Bienvenidos a mi Cumpleaños!')).toBeVisible();
   });
 });

--- a/frontend/testsprite_tests/quiz.spec.ts
+++ b/frontend/testsprite_tests/quiz.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from '@playwright/test';
 test.describe('Quiz Page Question Answering', () => {
   test.beforeEach(async ({ page }) => {
     // First register to be able to access quiz
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('TestPlayer');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
   });
 
   test('should display quiz page header with player name', async ({ page }) => {
@@ -118,15 +118,15 @@ test.describe('Quiz Page Question Answering', () => {
     await page.getByRole('button', { name: /Enviar Respuestas/i }).click();
     
     // Verify navigation
-    await expect(page).toHaveURL(/.*thank-you/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/ranking/);
   });
 
   test('should redirect to register if accessing quiz directly without name', async ({ page }) => {
     // Clear storage and navigate directly
     await page.evaluate(() => localStorage.clear());
-    await page.goto('http://localhost:5173/quiz');
+    await page.goto('/event/mile-2026/quiz');
     
-    // Should redirect to register
-    await expect(page).toHaveURL(/.*register/);
+    // Should redirect to register (event-scoped)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
   });
 });

--- a/frontend/testsprite_tests/register.spec.ts
+++ b/frontend/testsprite_tests/register.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Register Page Form Validation', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
   });
 
   test('should display register form elements', async ({ page }) => {
@@ -30,7 +30,7 @@ test.describe('Register Page Form Validation', () => {
     await expect(page.getByText('Por favor ingresa tu nombre')).toBeVisible();
     
     // Verify we stayed on register page
-    await expect(page).toHaveURL(/.*register/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
   });
 
   test('should show error for whitespace-only name', async ({ page }) => {
@@ -47,8 +47,8 @@ test.describe('Register Page Form Validation', () => {
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('María');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
-    // Verify navigation to quiz page
-    await expect(page).toHaveURL(/.*quiz/);
+    // Verify navigation to quiz page (event-scoped)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     await expect(page.getByText('¡Juguemos!')).toBeVisible();
   });
 
@@ -58,8 +58,8 @@ test.describe('Register Page Form Validation', () => {
     await page.getByPlaceholder(/Escribe tu nombre/i).fill(longName);
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
-    // Verify navigation
-    await expect(page).toHaveURL(/.*quiz/);
+    // Verify navigation (event-scoped)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
   });
 
   test('should clear error when user starts typing', async ({ page }) => {

--- a/frontend/testsprite_tests/routing.spec.ts
+++ b/frontend/testsprite_tests/routing.spec.ts
@@ -2,29 +2,29 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Routing Between Pages', () => {
   test('should route to home page at root path', async ({ page }) => {
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
     await expect(page.getByText('¡Bienvenidos a mi Cumpleaños!')).toBeVisible();
   });
 
   test('should route to register page', async ({ page }) => {
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await expect(page.getByText('Registro')).toBeVisible();
   });
 
   test('should route to quiz page with registered user', async ({ page }) => {
     // Register first
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('RouterTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
-    // Verify quiz page
-    await expect(page).toHaveURL(/.*quiz/);
+    // Verify quiz page (redirected to /event/mile-2026/quiz)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     await expect(page.getByText('¡Juguemos!')).toBeVisible();
   });
 
   test('should route to thank you page after quiz submission', async ({ page }) => {
     // Complete quiz
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('RouterTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
@@ -35,71 +35,73 @@ test.describe('Routing Between Pages', () => {
     }
     await page.getByRole('button', { name: /Enviar Respuestas/i }).click();
     
-    // Verify thank you page
-    await expect(page).toHaveURL(/.*thank-you/);
+    // Verify thank you page (redirected to /event/mile-2026/ranking)
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/ranking/);
     await expect(page.getByText('¡Gracias por participar!')).toBeVisible();
   });
 
   test('should route to ranking page', async ({ page }) => {
-    await page.goto('http://localhost:5173/ranking');
+    // /ranking redirects to /event/mile-2026/ranking
+    await page.goto('/ranking');
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/ranking/);
     await expect(page.getByText('Ranking')).toBeVisible();
   });
 
   test('should handle 404 for unknown routes', async ({ page }) => {
-    await page.goto('http://localhost:5173/nonexistent-page');
+    await page.goto('/nonexistent-page');
     await expect(page.getByText('404')).toBeVisible();
     await expect(page.getByText('Página no encontrada')).toBeVisible();
   });
 
   test('should maintain history when navigating', async ({ page }) => {
     // Start at welcome
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
     
     // Go to register
     await page.getByRole('button', { name: /Empezar Juego/i }).click();
-    await expect(page).toHaveURL(/.*register/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
     
     // Go back using browser back
     await page.goBack();
-    await expect(page).toHaveURL('http://localhost:5173/');
+    await expect(page).toHaveURL(/\/$/);
     await expect(page.getByText('¡Bienvenidos a mi Cumpleaños!')).toBeVisible();
     
     // Go forward
     await page.goForward();
-    await expect(page).toHaveURL(/.*register/);
+    await expect(page).toHaveURL(/.*\/register/);
   });
 
   test('should handle deep linking to quiz without registration', async ({ page }) => {
     // Navigate to app first, then clear any existing state
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
     await page.evaluate(() => localStorage.clear());
     
     // Try to access quiz directly
-    await page.goto('http://localhost:5173/quiz');
+    await page.goto('/event/mile-2026/quiz');
     
     // Should redirect to register
-    await expect(page).toHaveURL(/.*register/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
     await expect(page.getByText('Registro')).toBeVisible();
   });
 
   test('should preserve query parameters during navigation', async ({ page }) => {
     // Navigate with query params
-    await page.goto('http://localhost:5173/register?ref=test123');
+    await page.goto('/event/mile-2026/register?ref=test123');
     
     // Fill form and submit
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('QueryTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
     // Should navigate to quiz (query params may be stripped or preserved based on implementation)
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
   });
 
   test('should handle rapid route changes', async ({ page }) => {
     // Rapidly navigate between pages
-    await page.goto('http://localhost:5173/');
-    await page.goto('http://localhost:5173/register');
-    await page.goto('http://localhost:5173/ranking');
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
+    await page.goto('/register');
+    await page.goto('/ranking');
+    await page.goto('/');
     
     // Final page should be welcome
     await expect(page.getByText('¡Bienvenidos a mi Cumpleaños!')).toBeVisible();

--- a/frontend/testsprite_tests/welcome.spec.ts
+++ b/frontend/testsprite_tests/welcome.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Welcome Page Tests', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
   });
 
   test('should display welcome page elements', async ({ page }) => {
@@ -38,8 +38,8 @@ test.describe('Welcome Page Tests', () => {
     // Click start button
     await page.getByRole('button', { name: /Empezar Juego/i }).click();
     
-    // Verify navigation
-    await expect(page).toHaveURL(/.*register/);
+    // Verify navigation to event-scoped register page
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
     
     // Check registration form elements
     await expect(page.getByText('Nombre de la Princesa/Invitado')).toBeVisible();

--- a/frontend/testsprite_tests/zustand.spec.ts
+++ b/frontend/testsprite_tests/zustand.spec.ts
@@ -2,19 +2,19 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Zustand State Management', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
     // Clear localStorage before each test
     await page.evaluate(() => localStorage.clear());
   });
 
   test('should persist player name in store', async ({ page }) => {
     // Navigate to register and enter name
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('PersistentPlayer');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
     // Navigate to quiz and verify name is displayed
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     await expect(page.getByText('¿Qué tanto conoces a Mile, PersistentPlayer?')).toBeVisible();
     
     // Reload page and verify name persists
@@ -24,12 +24,12 @@ test.describe('Zustand State Management', () => {
 
   test('should persist quiz answers across page reloads', async ({ page }) => {
     // Go through registration
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('AnswerTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
     // Wait for quiz page to be ready
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     await expect(page.getByText('¡Juguemos!')).toBeVisible();
     
     // Answer a question
@@ -52,7 +52,7 @@ test.describe('Zustand State Management', () => {
     // Score is calculated server-side after submission; there is no live score UI element
     // with class "bg-primary/20" on the quiz page. Skipping this test.
     // Go through registration and answer correctly
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('ScoreTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
@@ -74,7 +74,7 @@ test.describe('Zustand State Management', () => {
 
   test('should reset quiz state when starting new game', async ({ page }) => {
     // Complete a quiz first
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('ResetTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
@@ -85,7 +85,7 @@ test.describe('Zustand State Management', () => {
     }
     
     // Go back to welcome
-    await page.goto('http://localhost:5173/');
+    await page.goto('/');
     
     // Start new game
     await page.getByRole('button', { name: /Empezar Juego/i }).click();
@@ -100,28 +100,28 @@ test.describe('Zustand State Management', () => {
 
   test('should clear localStorage on manual clear', async ({ page }) => {
     // Set up some data
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('ClearTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     
     // Clear localStorage and then reload to force Zustand to re-hydrate from empty storage
     await page.evaluate(() => localStorage.clear());
     await page.reload();
     
     // After reload with empty localStorage, navigating to quiz should redirect to register
-    await page.goto('http://localhost:5173/quiz');
-    await expect(page).toHaveURL(/.*register/);
+    await page.goto('/event/mile-2026/quiz');
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/register/);
   });
 
   test('should handle concurrent store updates', async ({ page }) => {
     // Go to quiz
-    await page.goto('http://localhost:5173/register');
+    await page.goto('/event/mile-2026/register');
     await page.getByPlaceholder(/Escribe tu nombre/i).fill('ConcurrentTester');
     await page.getByRole('button', { name: /¡Listos para jugar!/i }).click();
     
     // Wait for quiz to be ready
-    await expect(page).toHaveURL(/.*quiz/);
+    await expect(page).toHaveURL(/.*\/event\/mile-2026\/quiz/);
     await expect(page.getByText('¡Juguemos!')).toBeVisible();
     
     // Answer multiple questions (sequentially to ensure each update is captured)


### PR DESCRIPTION


- Added SQL migration to seed quiz questions for the legacy event 'mile-2026'.
- Updated nginx configuration to disable absolute redirects for better port handling.
- Introduced a custom hook `useEventNavigate` to prepend event slug in navigation.
- Updated various components and pages to use `useEventNavigate` for consistent routing.
- Added a registration page route within the event context.
- Modified Playwright tests to reflect new event-scoped navigation.