### PR TITLE
chore(config): remove legacy global secret token envs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -687,7 +687,7 @@ REFRESH_TOKEN_EXPIRY_DAYS=7
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:8080
 
 # Secret Box
-SECRET_BOX_TOKEN=un-token-seguro-compartido-por-whatsapp
+# El token se genera por evento desde el panel admin y se valida vía X-Secret-Token
 
 # Frontend
 VITE_API_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -165,9 +165,8 @@ DB_NAME=milegame
 # CORS (agregar dominios de producción aquí)
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:8081
 
-# Secret Box (generar tokens seguros antes de la fiesta)
-SECRET_BOX_TOKEN=token-secreto-para-el-link   # Token del link compartible
-ADMIN_PASSPHRASE=passphrase-del-admin          # Contraseña del panel admin
+# Secret Box
+# El token se genera por evento desde el panel admin (no hace falta env global)
 
 # Feature flags (habilitar funcionalidades)
 VITE_ENABLE_CORKBOARD=true
@@ -204,13 +203,11 @@ milegame-web   nginx                            Up (healthy)   0.0.0.0:8081->80/
 
 La **Secret Box** permite que familiares o amigos que no pueden asistir envíen fotos y mensajes secretos para el homenajeado. Se guardan ocultos y se revelan con una animación durante la celebración.
 
-### **Paso 1 — Configurar tokens antes de la fiesta**
+### **Paso 1 — Habilitar la feature antes de la fiesta**
 
-Editá el `.env` con valores seguros (no usar los defaults en producción):
+Editá el `.env` para habilitar la feature si hace falta:
 
 ```env
-SECRET_BOX_TOKEN=TmG_2026_x4Qp!9zBf7L       # Lo que va en el link compartible
-ADMIN_PASSPHRASE=Adm!n_Secr3t_9vL2#         # Para acceder al panel de admin
 VITE_ENABLE_SECRET_BOX=true                 # Habilitar la feature
 ```
 
@@ -220,30 +217,30 @@ Rebuild necesario si cambiás `VITE_ENABLE_SECRET_BOX` (está bakeado en el bund
 docker-compose up -d --build
 ```
 
-### **Paso 2 — Construir el link a compartir**
+### **Paso 2 — Generar el link a compartir desde el panel admin**
 
-La URL tiene el siguiente formato:
+El token ya no viene de una env global. Se genera por evento desde el panel admin y el link compartible tiene este formato:
 
 ```
-http://<HOST>/secret-box?token=<SECRET_BOX_TOKEN>
+http://<HOST>/e/<EVENT_SLUG>/secret-box?token=<TOKEN_GENERADO>
 ```
 
 **Ejemplos:**
 
 | Entorno | URL |
 |---------|-----|
-| Local | `http://localhost:8081/secret-box?token=cumple-mile-2026-secreto` |
-| Red local (fiesta) | `http://192.168.100.82:8081/secret-box?token=cumple-mile-2026-secreto` |
-| Producción | `https://milejuego.com/secret-box?token=cumple-mile-2026-secreto` |
+| Local | `http://localhost:8081/e/mi-evento/secret-box?token=abc123` |
+| Red local (fiesta) | `http://192.168.100.82:8081/e/mi-evento/secret-box?token=abc123` |
+| Producción | `https://midominio.com/e/mi-evento/secret-box?token=abc123` |
 
-> ⚠️ **El token en la URL debe coincidir exactamente con `SECRET_BOX_TOKEN` en el `.env`.**
+> ⚠️ **El token en la URL debe coincidir exactamente con el token generado para ese evento desde el panel admin.**
 
 ### **Paso 3 — Compartir el link**
 
 Enviá el link por **WhatsApp, email o cualquier canal** a las personas que no pueden asistir. Cada persona:
 
 1. Abre el link en su celular
-2. Sube una foto y escribe un mensaje para Mile
+2. Sube una foto y escribe un mensaje para el homenajeado
 3. Ve una confirmación de envío exitoso
 
 No necesitan registrarse ni haber jugado el quiz.
@@ -252,15 +249,7 @@ No necesitan registrarse ni haber jugado el quiz.
 
 El panel de admin te muestra cuántas postales secretas fueron enviadas y un preview de cada una:
 
-```
-http://<HOST>/admin?key=<ADMIN_PASSPHRASE>
-```
-
-**Ejemplo:**
-
-```
-http://192.168.100.82:8081/admin?key=solo-yo-lo-se-123
-```
+El acceso admin ahora usa login con JWT y ownership del evento; ya no usa passphrase por query param.
 
 ### **Paso 5 — Revelar la Secret Box durante la fiesta**
 
@@ -281,13 +270,13 @@ Cuando llegue el momento emotivo, desde el panel admin:
 
 **El link dice "Token inválido":**
 - Verificá que `VITE_ENABLE_SECRET_BOX=true` en el `.env` y que hiciste rebuild
-- Verificá que el token en la URL coincide exactamente con `SECRET_BOX_TOKEN` (case-sensitive, sin espacios)
+- Verificá que el token en la URL coincide exactamente con el token generado para ese evento (case-sensitive, sin espacios)
 
 **La ruta `/secret-box` no existe (404):**
 - La feature está deshabilitada. Verificá `VITE_ENABLE_SECRET_BOX=true` y rebuild del frontend
 
 **El admin dice "No autorizado":**
-- El valor del query param `key` debe coincidir exactamente con `ADMIN_PASSPHRASE` en el `.env`
+- Verificá que estás logueado como owner del evento
 
 **Resetear estado del reveal (para volver a ejecutar la animación):**
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -117,7 +117,7 @@ func main() {
 	config.AllowOrigins = strings.Split(allowedOrigins, ",")
 
 	config.AllowMethods = []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}
-	config.AllowHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization", "X-Player-ID", "X-Secret-Token", "X-Admin-Key"}
+	config.AllowHeaders = []string{"Origin", "Content-Type", "Accept", "Authorization", "X-Player-ID", "X-Secret-Token"}
 	config.AllowCredentials = true
 	r.Use(cors.New(config))
 

--- a/backend/internal/handlers/handlers_test.go
+++ b/backend/internal/handlers/handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 	"time"
 
@@ -326,12 +325,16 @@ func TestSecretPostcardAutoRevealLogic(t *testing.T) {
 
 			tmpDir := t.TempDir()
 			h := &Handler{postcardRepo: repo, hub: hub, uploadsDir: tmpDir}
-
-			os.Setenv("SECRET_BOX_TOKEN", "test-token")
-			defer os.Unsetenv("SECRET_BOX_TOKEN")
+			eventToken := "test-token"
+			event := &models.Event{ID: uuid.New(), Slug: "test-event", IsActive: true, SecretBoxToken: &eventToken}
 
 			r := gin.New()
-			r.POST("/api/postcards/secret", h.CreateSecretPostcard)
+			r.POST("/api/postcards/secret", func(c *gin.Context) {
+				c.Set("event", event)
+				c.Set("event_id", event.ID)
+				c.Set("event_slug", event.Slug)
+				h.CreateSecretPostcard(c)
+			})
 
 			var body bytes.Buffer
 			mw := multipart.NewWriter(&body)
@@ -370,20 +373,16 @@ func TestSecretPostcardAutoRevealLogic(t *testing.T) {
 
 func TestCreateSecretPostcardMissingToken(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-
-	// Setear el token esperado en el entorno
-	os.Setenv("SECRET_BOX_TOKEN", "test-secret-token")
-	defer os.Unsetenv("SECRET_BOX_TOKEN")
+	eventToken := "test-secret-token"
+	event := &models.Event{ID: uuid.New(), Slug: "test-event", IsActive: true, SecretBoxToken: &eventToken}
 
 	r := gin.New()
 	r.POST("/api/postcards/secret", func(c *gin.Context) {
-		token := c.GetHeader("X-Secret-Token")
-		expected := os.Getenv("SECRET_BOX_TOKEN")
-		if expected == "" || token != expected {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or missing secret token"})
-			return
-		}
-		c.JSON(http.StatusCreated, gin.H{"id": uuid.New().String()})
+		c.Set("event", event)
+		c.Set("event_id", event.ID)
+		c.Set("event_slug", event.Slug)
+		h := &Handler{}
+		h.CreateSecretPostcard(c)
 	})
 
 	tests := []struct {
@@ -393,7 +392,7 @@ func TestCreateSecretPostcardMissingToken(t *testing.T) {
 	}{
 		{"no token", "", http.StatusUnauthorized},
 		{"wrong token", "wrong-token", http.StatusUnauthorized},
-		{"correct token", "test-secret-token", http.StatusCreated},
+		{"correct token", "test-secret-token", http.StatusBadRequest},
 	}
 
 	for _, tt := range tests {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:3000,http://localhost:8081,http://localhost,http://192.168.100.82:8081}
       UPLOADS_DIR: /app/uploads
-      SECRET_BOX_TOKEN: ${SECRET_BOX_TOKEN:-changeme-secret-token}
-      ADMIN_PASSPHRASE: ${ADMIN_PASSPHRASE:-changeme-admin-key}
     volumes:
       - uploads_data:/app/uploads
     networks:

--- a/docs/api/POSTCARDS.md
+++ b/docs/api/POSTCARDS.md
@@ -160,9 +160,9 @@ curl -X POST http://localhost:8080/api/postcards \
 ### Create Secret Postcard
 
 ```
-POST /api/postcards/secret
+POST /api/events/:slug/secret-box
 Content-Type: multipart/form-data
-X-Secret-Token: {SECRET_BOX_TOKEN}
+X-Secret-Token: {EVENT_SECRET_BOX_TOKEN}
 ```
 
 Secret postcards are hidden until the admin reveals them via WebSocket.
@@ -172,17 +172,15 @@ Secret postcards are hidden until the admin reveals them via WebSocket.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `media` OR `image` | file | Yes | Media file |
-| `event_id` | string | Yes | Event UUID |
 | `sender_name` | string | Yes | Name of the sender |
 | `message` | string | No | Message |
 
 **Example:**
 
 ```bash
-curl -X POST http://localhost:8080/api/postcards/secret \
-  -H "X-Secret-Token: {SECRET_BOX_TOKEN}" \
+curl -X POST http://localhost:8080/api/events/ale-roy/secret-box \
+  -H "X-Secret-Token: {EVENT_SECRET_BOX_TOKEN}" \
   -F "image=@surprise.jpg" \
-  -F "event_id=550e8400-e29b-41d4-a716-446655440001" \
   -F "sender_name=Tío Juan" \
   -F "message=I couldn't make it but wanted to say..."
 ```

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -66,7 +66,7 @@ See [Authentication](AUTH.md) for details on obtaining tokens.
 |--------|----------|-------------|------|
 | GET | `/postcards` | List postcards (query: ?event_id=) | No |
 | POST | `/postcards` | Create postcard (image OR media) | Yes (Player) |
-| POST | `/postcards/secret` | Create secret postcard | No (X-Secret-Token) |
+| POST | `/events/:slug/secret-box` | Create secret postcard | No (X-Secret-Token for that event) |
 
 ### Themes
 | Method | Endpoint | Description | Auth |

--- a/frontend/src/shared/lib/__tests__/api.test.ts
+++ b/frontend/src/shared/lib/__tests__/api.test.ts
@@ -193,17 +193,12 @@ describe('ApiClient', () => {
   // ─── getSecretBoxStatus ──────────────────────────────────────────────────────
 
   describe('getSecretBoxStatus', () => {
-    it('GETs /admin/status with X-Admin-Key header', async () => {
+    it('GETs /admin/status without legacy admin headers', async () => {
       mockGet.mockResolvedValueOnce({ data: { total: 5, revealed: false, revealed_at: null } })
 
       await api.getSecretBoxStatus()
 
-      expect(mockGet).toHaveBeenCalledWith(
-        '/admin/status',
-        expect.objectContaining({
-          headers: expect.objectContaining({ 'X-Admin-Key': 'admin-passphrase' }),
-        })
-      )
+      expect(mockGet).toHaveBeenCalledWith('/admin/status')
     })
 
     it('returns the secret box status', async () => {
@@ -218,17 +213,12 @@ describe('ApiClient', () => {
   // ─── listSecretPostcards ─────────────────────────────────────────────────────
 
   describe('listSecretPostcards', () => {
-    it('GETs /admin/secret-box with X-Admin-Key header', async () => {
+    it('GETs /admin/secret-box without legacy admin headers', async () => {
       mockGet.mockResolvedValueOnce({ data: [] })
 
       await api.listSecretPostcards()
 
-      expect(mockGet).toHaveBeenCalledWith(
-        '/admin/secret-box',
-        expect.objectContaining({
-          headers: expect.objectContaining({ 'X-Admin-Key': 'admin-passphrase' }),
-        })
-      )
+      expect(mockGet).toHaveBeenCalledWith('/admin/secret-box')
     })
 
     it('returns the list of secret postcards', async () => {
@@ -329,18 +319,12 @@ describe('ApiClient', () => {
   // ─── revealSecretBox ─────────────────────────────────────────────────────────
 
   describe('revealSecretBox', () => {
-    it('POSTs to /admin/reveal with X-Admin-Key header', async () => {
+    it('POSTs to /admin/reveal without legacy admin headers', async () => {
       mockPost.mockResolvedValueOnce({ data: { message: 'Revealed!', postcards: [] } })
 
       await api.revealSecretBox()
 
-      expect(mockPost).toHaveBeenCalledWith(
-        '/admin/reveal',
-        {},
-        expect.objectContaining({
-          headers: expect.objectContaining({ 'X-Admin-Key': 'admin-passphrase' }),
-        })
-      )
+      expect(mockPost).toHaveBeenCalledWith('/admin/reveal', {})
     })
 
     it('returns the revealed postcards', async () => {


### PR DESCRIPTION
Closes #47

## Summary
- remove obsolete global Secret Box/admin env configuration now that tokens are event-scoped and admin access uses JWT ownership
- update tests and CORS headers to stop implying support for the old admin passphrase header flow
- refresh docs so Secret Box setup and API examples match the current event-scoped token model

## Changes
| File | Change |
|------|--------|
| `docker-compose.yml` | remove legacy `SECRET_BOX_TOKEN` and `ADMIN_PASSPHRASE` backend env vars |
| `backend/cmd/api/main.go` | remove `X-Admin-Key` from allowed CORS headers |
| `backend/internal/handlers/handlers_test.go` | update secret postcard tests to use event-scoped tokens instead of env globals |
| `frontend/src/shared/lib/__tests__/api.test.ts` | remove legacy admin-header expectations from API tests |
| `README.md` | document Secret Box token generation per event and JWT-based admin access |
| `docs/api/README.md` | update secret postcard endpoint docs to the event-scoped route |
| `docs/api/POSTCARDS.md` | update examples to use event-scoped Secret Box tokens |
| `AGENTS.md` | remove misleading global Secret Box token env example |

## Test Plan
- [x] `cd backend && go test ./internal/handlers/...`
- [x] `cd backend && go build ./...`
- [ ] frontend Vitest suite still needs independent axios interceptor mock cleanup (pre-existing issue)

## Notes
- `X-Secret-Token` remains valid as a request header, but its value is now generated per event from admin APIs rather than loaded from a global env var.