### PR TITLE
fix(event): correct event creation redirect, postcard 403, and missing delete endpoint

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -251,6 +251,8 @@ func main() {
 		adminEvents.Use(authMiddleware)
 		adminEvents.Use(middleware.OwnerMiddleware())
 		{
+			// Event management
+			adminEvents.DELETE("", eventHandler.DeleteEvent)
 			adminEvents.GET("/status", handler.GetSecretBoxStatus)
 			adminEvents.GET("/secret-box", handler.ListSecretPostcards)
 			adminEvents.POST("/reveal", handler.RevealSecretBox)

--- a/backend/internal/handlers/event_user_handlers.go
+++ b/backend/internal/handlers/event_user_handlers.go
@@ -17,6 +17,7 @@ type EventRepo interface {
 	Create(ownerID uuid.UUID, slug, name, description string,
 		features models.EventFeatures, settings models.EventSettings,
 		startsAt, endsAt *time.Time) (*models.Event, error)
+	Delete(id uuid.UUID) error
 }
 
 // EventHandler handles user event endpoints
@@ -134,4 +135,24 @@ func (h *EventHandler) CreateEvent(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, event)
+}
+
+// DeleteEvent deletes an event owned by the authenticated user.
+// Expects the event to already be loaded in context by EventMiddleware,
+// and ownership verified by OwnerMiddleware (admin route).
+func (h *EventHandler) DeleteEvent(c *gin.Context) {
+	event, exists := c.Get("event")
+	if !exists {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Event not in context"})
+		return
+	}
+
+	eventModel := event.(*models.Event)
+
+	if err := h.eventRepo.Delete(eventModel.ID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete event"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Event deleted"})
 }

--- a/backend/internal/handlers/event_user_handlers_test.go
+++ b/backend/internal/handlers/event_user_handlers_test.go
@@ -49,6 +49,19 @@ func (m *MockUserEventRepo) Create(ownerID uuid.UUID, slug, name, description st
 	return event, nil
 }
 
+func (m *MockUserEventRepo) Delete(id uuid.UUID) error {
+	if m.Err != nil {
+		return m.Err
+	}
+	for i, e := range m.Events {
+		if e.ID == id {
+			m.Events = append(m.Events[:i], m.Events[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
 // ========== TESTS FOR GetUserEvents ==========
 
 func TestGetUserEvents_Success(t *testing.T) {
@@ -174,6 +187,59 @@ func TestGetUserEvents_Error(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/api/users/me/events", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status %d, got %d", http.StatusInternalServerError, w.Code)
+	}
+}
+
+// ========== TESTS FOR DeleteEvent ==========
+
+func TestDeleteEvent_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	eventID := uuid.New()
+	events := []models.Event{
+		{ID: eventID, Slug: "test-event", Name: "Test", IsActive: true, CreatedAt: time.Now()},
+	}
+
+	mockRepo := &MockUserEventRepo{Events: events}
+	handler := &EventHandler{eventRepo: mockRepo}
+
+	r := gin.New()
+	r.DELETE("/api/admin/events/:slug", func(c *gin.Context) {
+		c.Set("event", &events[0])
+		handler.DeleteEvent(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/admin/events/test-event", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	if len(mockRepo.Events) != 0 {
+		t.Errorf("Expected 0 events after delete, got %d", len(mockRepo.Events))
+	}
+}
+
+func TestDeleteEvent_Error(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mockRepo := &MockUserEventRepo{Err: errors.New("database error")}
+	handler := &EventHandler{eventRepo: mockRepo}
+
+	r := gin.New()
+	r.DELETE("/api/admin/events/:slug", func(c *gin.Context) {
+		c.Set("event", &models.Event{ID: uuid.New(), Slug: "test-event"})
+		handler.DeleteEvent(c)
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/admin/events/test-event", nil)
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusInternalServerError {

--- a/frontend/src/features/dashboard/components/EventCard.tsx
+++ b/frontend/src/features/dashboard/components/EventCard.tsx
@@ -6,7 +6,7 @@ import type { Event } from '@/shared/lib/api';
 
 interface EventCardProps {
   event: Event;
-  onDelete?: (id: string) => void;
+  onDelete?: (slug: string) => void;
 }
 
 // Theme color mappings for event cards
@@ -44,7 +44,7 @@ export function EventCard({ event, onDelete }: EventCardProps) {
 
   const handleDelete = () => {
     if (onDelete && confirm('¿Estás seguro de eliminar este evento?')) {
-      onDelete(event.id);
+      onDelete(event.slug);
     }
     setShowMenu(false);
   };

--- a/frontend/src/features/dashboard/store/dashboardStore.ts
+++ b/frontend/src/features/dashboard/store/dashboardStore.ts
@@ -10,7 +10,7 @@ interface DashboardState {
   
   // Actions
   fetchEvents: () => Promise<void>;
-  deleteEvent: (id: string) => Promise<void>;
+  deleteEvent: (slug: string) => Promise<void>;
   clearError: () => void;
 }
 
@@ -33,13 +33,13 @@ export const useDashboardStore = create<DashboardState>((set) => ({
     }
   },
 
-  deleteEvent: async (id: string) => {
+  deleteEvent: async (slug: string) => {
     try {
-      // Call delete endpoint
-      await api.delete(`/events/${id}`);
+      // Call delete endpoint (requires slug, which resolves to the event via admin middleware)
+      await api.delete(`/admin/events/${slug}`);
       // Update local state
       set((state) => ({
-        events: state.events.filter((e) => e.id !== id),
+        events: state.events.filter((e) => e.slug !== slug),
       }));
     } catch (error) {
       console.error('Error deleting event:', error);

--- a/frontend/src/features/event-wizard/pages/EventWizardPage.tsx
+++ b/frontend/src/features/event-wizard/pages/EventWizardPage.tsx
@@ -59,9 +59,13 @@ export function EventWizardPage() {
         }
       }
 
+      if (!newEvent.slug) {
+        throw new Error('El evento se creo, pero no se recibio un slug valido para redirigir al panel admin.');
+      }
+
       reset();
       console.log('Event created, redirecting to:', newEvent.slug);
-      navigate(`/e/${newEvent.slug}/admin?tab=config`, { replace: true });
+      navigate(`/admin/${newEvent.slug}?tab=config`, { replace: true });
     } catch (err) {
       console.error('Error creating event:', err);
       setSubmitError(

--- a/frontend/src/shared/lib/__tests__/api.test.ts
+++ b/frontend/src/shared/lib/__tests__/api.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // vi.hoisted ensures these are available inside vi.mock factories (before imports)
-const { mockPost, mockGet, mockInterceptorsUse } = vi.hoisted(() => ({
+const { mockPost, mockGet, mockInterceptorsUse, mockRequestInterceptorsUse } = vi.hoisted(() => ({
   mockPost: vi.fn(),
   mockGet: vi.fn(),
   mockInterceptorsUse: vi.fn(),
+  mockRequestInterceptorsUse: vi.fn(),
 }))
 
 vi.mock('axios', () => ({
@@ -13,6 +14,7 @@ vi.mock('axios', () => ({
       post: mockPost,
       get: mockGet,
       interceptors: {
+        request: { use: mockRequestInterceptorsUse },
         response: { use: mockInterceptorsUse },
       },
     })),
@@ -313,6 +315,49 @@ describe('ApiClient', () => {
 
       const formDataArg = mockPost.mock.calls[0][1] as FormData
       expect(formDataArg.get('sender_name')).toBeNull()
+    })
+  })
+
+  describe('createPostcardScoped', () => {
+    it('reuses the current player only when it belongs to the same event', async () => {
+      api.setPlayerId('event-player-uuid', 'ale-roy')
+      mockPost.mockResolvedValueOnce({ data: { id: 'pc-1', message: 'Hola!' } })
+
+      const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' })
+      await api.createPostcardScoped('ale-roy', file, 'Hola!', { senderName: 'Laura' })
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/events/ale-roy/postcards',
+        expect.any(FormData),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Player-ID': 'event-player-uuid' }),
+        })
+      )
+    })
+
+    it('creates a guest player when the stored player belongs to another event', async () => {
+      api.setPlayerId('other-event-player', 'cumple-meli')
+      const guest = { id: 'guest-uuid', name: 'Laura', avatar: '📸', score: 0, created_at: '' }
+      const postcard = { id: 'pc-2', message: 'Hola!', sender_name: 'Laura', is_secret: false }
+
+      mockPost
+        .mockResolvedValueOnce({ data: guest })
+        .mockResolvedValueOnce({ data: postcard })
+
+      const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' })
+      const result = await api.createPostcardScoped('ale-roy', file, 'Hola!', { senderName: 'Laura' })
+
+      expect(mockPost).toHaveBeenNthCalledWith(1, '/events/ale-roy/players', { name: 'Laura', avatar: '📸' })
+      expect(mockPost).toHaveBeenNthCalledWith(
+        2,
+        '/events/ale-roy/postcards',
+        expect.any(FormData),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Player-ID': 'guest-uuid' }),
+        })
+      )
+      expect(api.getPlayerEventSlug()).toBe('ale-roy')
+      expect(result).toEqual(postcard)
     })
   })
 

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -540,7 +540,7 @@ class ApiClient {
     message: string, 
     options?: { senderName?: string; name?: string; avatar?: string }
   ): Promise<Postcard> {
-    let effectivePlayerId = this.playerId;
+    let effectivePlayerId = this.isPlayerForEvent(eventSlug) ? this.playerId : null;
 
     // Auto-registro: si no hay jugador y se provee name+avatar, registrar como invitado
     if (!effectivePlayerId && options?.name && options?.avatar) {


### PR DESCRIPTION
Closes #51

## Summary
Fixes three bugs affecting event flows: broken redirect after creation, 403 on postcard upload from cross-event player IDs, and non-functional event deletion.

## Changes
| File | Change |
|------|--------|
| `frontend/.../EventWizardPage.tsx` | Redirect `/e/:slug/admin` → `/admin/:slug` after event creation |
| `frontend/.../api.ts` | Only reuse player if it belongs to the same event |
| `frontend/.../api.test.ts` | Add scoped postcard player tests |
| `backend/.../event_user_handlers.go` | New `DeleteEvent` handler + `Delete` in repo interface |
| `backend/.../event_user_handlers_test.go` | Mock + tests for `DeleteEvent` |
| `backend/cmd/api/main.go` | Register `DELETE /admin/events/:slug` route |
| `frontend/.../dashboardStore.ts` | Use slug + `/admin/events/:slug` for delete |
| `frontend/.../EventCard.tsx` | Pass slug to delete callback |

## Validation
- [x] `go test ./internal/handlers/` — all pass
- [x] `go vet ./...` — clean
- [x] `npx vitest run api.test.ts` — 29 tests pass