### PR TITLE
fix(ui): butterfly theme-only, button spacing, and theme preview consistency

### DIFF
--- a/frontend/src/features/event-admin/components/ThemeTab.tsx
+++ b/frontend/src/features/event-admin/components/ThemeTab.tsx
@@ -186,6 +186,7 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
+          className="space-y-3"
         >
           <Button
             variant="primary"
@@ -203,23 +204,41 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
           >
             Guardar Tema
           </Button>
+
+          <Link to={`/admin/${slug}/theme`} className="block">
+            <Button
+              variant="primary"
+              fullWidth
+              icon={<Palette className="w-4 h-4" />}
+              style={{ 
+                backgroundColor: theme.secondaryColor,
+                color: theme.accentColor || theme.primaryColor,
+                border: `1px solid ${theme.primaryColor}30`
+              }}
+            >
+              Personalizar Tema
+            </Button>
+          </Link>
         </motion.div>
       )}
 
-      <Link to={`/admin/${slug}/theme`} className="block">
-        <Button
-          variant="primary"
-          fullWidth
-          icon={<Palette className="w-4 h-4" />}
-          style={{ 
-            backgroundColor: theme.secondaryColor,
-            color: theme.accentColor || theme.primaryColor,
-            border: `1px solid ${theme.primaryColor}30`
-          }}
-        >
-          Personalizar Tema
-        </Button>
-      </Link>
+      {/* Show customizer link even if no preset selected */}
+      {!selectedPreset && (
+        <Link to={`/admin/${slug}/theme`} className="block">
+          <Button
+            variant="primary"
+            fullWidth
+            icon={<Palette className="w-4 h-4" />}
+            style={{ 
+              backgroundColor: theme.secondaryColor,
+              color: theme.accentColor || theme.primaryColor,
+              border: `1px solid ${theme.primaryColor}30`
+            }}
+          >
+            Personalizar Tema
+          </Button>
+        </Link>
+      )}
 
       <div 
         className="rounded-xl p-4 text-sm"

--- a/frontend/src/features/event-wizard/components/Step2_Features.tsx
+++ b/frontend/src/features/event-wizard/components/Step2_Features.tsx
@@ -59,18 +59,20 @@ export function Step2_Features() {
       <div className="space-y-4">
         {featureItems.map((item) => (
           <div key={item.key} className="p-4 rounded-xl" style={item.bgStyle}>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-3">
-                <span className="text-2xl">{item.emoji}</span>
-                <div>
+            <div className="flex items-start gap-3">
+              <div className="flex min-w-0 flex-1 items-start gap-3">
+                <span className="shrink-0 text-2xl leading-none">{item.emoji}</span>
+                <div className="min-w-0 flex-1">
                   <p className="font-medium text-gray-800">{item.label}</p>
                   <p className="text-sm text-gray-500">{item.description}</p>
                 </div>
               </div>
-              <Switch
-                checked={formData.features[item.key]}
-                onChange={handleToggle(item.key)}
-              />
+              <div className="shrink-0 pt-0.5">
+                <Switch
+                  checked={formData.features[item.key]}
+                  onChange={handleToggle(item.key)}
+                />
+              </div>
             </div>
           </div>
         ))}

--- a/frontend/src/features/event-wizard/components/Step3_Theme.tsx
+++ b/frontend/src/features/event-wizard/components/Step3_Theme.tsx
@@ -94,7 +94,7 @@ export function Step3_Theme() {
           <p>No hay temas disponibles. Se usará el tema por defecto.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
           {presets.map((preset) => {
             const presetData = THEME_PRESETS.find(p => p.name === preset.name);
             const isSelected = selectedThemeId === preset.name;
@@ -104,7 +104,7 @@ export function Step3_Theme() {
                 key={preset.name}
                 onClick={() => handleSelect(preset)}
                 className={`
-                  relative h-24 rounded-xl p-4 border-2 transition-all duration-200
+                  relative flex min-h-[8.25rem] flex-col rounded-xl p-3 border-2 transition-all duration-200
                   hover:shadow-lg hover:scale-[1.02]
                   text-left
                   ${isSelected
@@ -117,20 +117,20 @@ export function Step3_Theme() {
                 }}
               >
                 <div
-                  className="h-20 rounded-lg mb-3"
+                  className="h-16 min-h-16 rounded-lg"
                   style={{
                     background: `linear-gradient(135deg, ${presetData?.primaryColor || '#F48FB1'} 0%, ${presetData?.secondaryColor || '#FBCFE8'} 100%)`,
                   }}
                 />
                 <p 
-                  className="text-sm font-medium capitalize"
+                  className="mt-2 text-sm font-medium capitalize leading-tight break-words"
                   style={{ color: 'var(--color-on-surface)' }}
                 >
-                  {preset.label || preset.name}
+                  {presetData?.label || preset.name}
                 </p>
                 {isSelected && (
                   <div 
-                    className="absolute top-2 right-2 w-6 h-6 bg-white rounded-full flex items-center justify-center shadow-sm"
+                    className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-white shadow-sm"
                   >
                     <span className="text-xs" style={{ color: presetData?.primaryColor || '#EC4899' }}>✓</span>
                   </div>

--- a/frontend/src/features/event-wizard/components/Step3_Theme.tsx
+++ b/frontend/src/features/event-wizard/components/Step3_Theme.tsx
@@ -94,7 +94,7 @@ export function Step3_Theme() {
           <p>No hay temas disponibles. Se usará el tema por defecto.</p>
         </div>
       ) : (
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
           {presets.map((preset) => {
             const presetData = THEME_PRESETS.find(p => p.name === preset.name);
             const isSelected = selectedThemeId === preset.name;
@@ -104,7 +104,7 @@ export function Step3_Theme() {
                 key={preset.name}
                 onClick={() => handleSelect(preset)}
                 className={`
-                  relative rounded-xl p-4 border-2 transition-all duration-200
+                  relative h-24 rounded-xl p-4 border-2 transition-all duration-200
                   hover:shadow-lg hover:scale-[1.02]
                   text-left
                   ${isSelected
@@ -117,20 +117,22 @@ export function Step3_Theme() {
                 }}
               >
                 <div
-                  className={`h-20 rounded-lg mb-3 bg-gradient-to-br ${presetData?.gradientFrom || 'from-pink-400'} ${presetData?.gradientTo || 'to-rose-500'}`}
+                  className="h-20 rounded-lg mb-3"
+                  style={{
+                    background: `linear-gradient(135deg, ${presetData?.primaryColor || '#F48FB1'} 0%, ${presetData?.secondaryColor || '#FBCFE8'} 100%)`,
+                  }}
                 />
                 <p 
                   className="text-sm font-medium capitalize"
                   style={{ color: 'var(--color-on-surface)' }}
                 >
-                  {preset.name}
+                  {preset.label || preset.name}
                 </p>
                 {isSelected && (
                   <div 
-                    className="absolute top-2 right-2 w-5 h-5 rounded-full flex items-center justify-center"
-                    style={{ backgroundColor: 'var(--color-primary)' }}
+                    className="absolute top-2 right-2 w-6 h-6 bg-white rounded-full flex items-center justify-center shadow-sm"
                   >
-                    <span className="text-white text-xs">✓</span>
+                    <span className="text-xs" style={{ color: presetData?.primaryColor || '#EC4899' }}>✓</span>
                   </div>
                 )}
               </button>

--- a/frontend/src/features/event-wizard/components/WizardNavigation.tsx
+++ b/frontend/src/features/event-wizard/components/WizardNavigation.tsx
@@ -17,27 +17,31 @@ export function WizardNavigation({ onSubmit }: WizardNavigationProps) {
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
-      className="flex items-center justify-between gap-4 pt-6 border-t border-[var(--color-border-light)]"
+      className="grid grid-cols-2 gap-4 pt-6 border-t border-[var(--color-border-light)]"
     >
-      <div>
+      <div className="min-w-0">
         {currentStep > 0 && (
           <Button
             variant="outline"
             onClick={prevStep}
             icon={<ArrowLeft className="w-4 h-4" />}
+            fullWidth
+            className="whitespace-nowrap"
           >
             Anterior
           </Button>
         )}
       </div>
 
-      <div className="flex items-center gap-3">
+      <div className="min-w-0">
         {isLastStep ? (
           <Button
             variant="primary"
             onClick={onSubmit}
             disabled={isSubmitting}
             isLoading={isSubmitting}
+            fullWidth
+            className="whitespace-nowrap"
           >
             {isSubmitting ? <LoadingSpinner size="sm" /> : 'Crear Evento'}
           </Button>
@@ -46,6 +50,8 @@ export function WizardNavigation({ onSubmit }: WizardNavigationProps) {
             variant="primary"
             onClick={nextStep}
             icon={<ArrowRight className="w-4 h-4" />}
+            fullWidth
+            className="whitespace-nowrap"
           >
             Siguiente
           </Button>

--- a/frontend/src/features/quiz/pages/QuizPage.tsx
+++ b/frontend/src/features/quiz/pages/QuizPage.tsx
@@ -64,7 +64,7 @@ function NoQuestionsState({ themeId }: { themeId?: string }) {
   const navigate = useEventNavigate();
 
   return (
-    <PageLayout background="butterfly-animated" showSparkles={false} themeId={themeId}>
+    <PageLayout background="theme" showSparkles={false} themeId={themeId}>
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 text-center min-h-[70vh]">
         <motion.div
           initial={{ scale: 0.8, opacity: 0 }}
@@ -178,7 +178,7 @@ export function QuizPage() {
   // Si las preguntas están cargando, mostrar loading
   if (loadingQuestions) {
     return (
-      <PageLayout background="butterfly-animated" showSparkles={false} themeId={currentEvent?.themeId}>
+      <PageLayout background="theme" showSparkles={false} themeId={currentEvent?.themeId}>
         <div className="flex-1 flex flex-col items-center justify-center px-6 py-12">
           <div className="animate-pulse flex flex-col items-center gap-4">
             <div className="w-16 h-16 rounded-full bg-primary/20" />
@@ -203,7 +203,7 @@ export function QuizPage() {
   const totalQuestions = favoriteQuestions.length + preferenceQuestions.length + (questions.some((q) => q.section === 'description') ? 1 : 0);
 
   return (
-    <PageLayout background="butterfly-animated" showSparkles={false} themeId={currentEvent?.themeId}>
+    <PageLayout background="theme" showSparkles={false} themeId={currentEvent?.themeId}>
       {/* Progress bar minimalista sticky */}
       <ProgressBarMinimal current={progress.current} total={totalQuestions || 1} />
 

--- a/frontend/src/features/quiz/pages/ThankYouPage.tsx
+++ b/frontend/src/features/quiz/pages/ThankYouPage.tsx
@@ -96,7 +96,7 @@ export function ThankYouPage() {
   };
 
   return (
-    <PageLayout background="butterfly-animated" showSparkles={false} themeId={currentEvent?.themeId}>
+    <PageLayout background="theme" showSparkles={false} themeId={currentEvent?.themeId}>
       {/* Efecto confetti basado en puntaje */}
       <ConfettiEffect score={score} isActive={hasCompleted} />
       

--- a/frontend/src/features/quiz/pages/WelcomePage.tsx
+++ b/frontend/src/features/quiz/pages/WelcomePage.tsx
@@ -14,7 +14,7 @@ export function WelcomePage() {
   // No hacer fallback hardcodeado a mile-2026 — dejar que falle si no hay evento
 
   return (
-    <PageLayout background="butterfly-animated" showSparkles={false} themeId={currentEvent?.themeId}>
+    <PageLayout background="theme" showSparkles={false} themeId={currentEvent?.themeId}>
       <div className="flex flex-col items-center flex-1 px-8 py-12 text-center">
         {/* Sección superior - Título */}
         <ScrollReveal variant="fadeDown" className="w-full h-1/3 flex flex-col items-center justify-center relative mt-4">

--- a/frontend/src/shared/components/PageLayout.tsx
+++ b/frontend/src/shared/components/PageLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { ButterflyBackground } from './ButterflyBackground';
 import { useTheme } from '@/shared/theme/useTheme';
+import { useEventStore } from '@/shared/store/eventStore';
 
 interface PageLayoutProps {
   children: ReactNode;
@@ -20,6 +21,7 @@ export function PageLayout({
   themeId: _themeId, // eslint-disable-line @typescript-eslint/no-unused-vars
 }: PageLayoutProps) {
   const { currentTheme: theme } = useTheme();
+  const { currentEvent } = useEventStore();
   
   // Check if we should show decorative background
   // For dark themes, skip decorative backgrounds to avoid color clashes
@@ -49,9 +51,13 @@ export function PageLayout({
     return bgClasses[background] || `theme-${theme.backgroundStyle || 'watercolor'}`;
   };
 
-  // Solo mostrar蝴蝶Background si background es butterfly-animated
-  // No condicionar a un tema específico - el background style ya lo determina
-  const showButterflyAnimation = background === 'butterfly-animated';
+  // Show butterfly animation ONLY when:
+  // 1. Explicitly requested via prop (legacy), OR
+  // 2. The event's theme is 'princess' (the only theme with butterfly animation)
+  const isPrincessTheme = currentEvent?.themeId === 'princess';
+  const showButterflyAnimation =
+    background === 'butterfly-animated' ||
+    (background === 'theme' && isPrincessTheme);
 
   // Get background color from theme
   const bgStyle = background === 'none' 


### PR DESCRIPTION
## Summary

Fixes 3 related UI polish issues in a single PR:

### 🦋 Butterfly animation only on princess theme (#59)
- Butterfly animation (`ButterflyBackground`) was hardcoded on ALL quiz pages regardless of event theme
- Now reads `currentEvent.themeId` from event store and only renders butterflies for `princess` theme
- Changed quiz pages from `background="butterfly-animated"` → `background="theme"` to respect event theme

### 🔲 Consistent button spacing (#63)
- "Guardar Tema" and "Personalizar Tema" buttons in ThemeTab were stacked with zero gap
- Added `space-y-3` between buttons for consistent spacing
- Reorganized button logic so "Personalizar Tema" always shows (whether or not a preset is selected)

### 🎨 Unified theme preview cards (#64)
- Wizard used Tailwind gradient classes (`from-pink-400 to-rose-500`) which may not match actual preset colors
- Admin used inline hex gradients which always show correct colors
- Now both use inline `linear-gradient(135deg, primaryColor, secondaryColor)`
- Unified card height (`h-24`), grid gap (`gap-3`), and selection indicator style

## Files Changed

| File | Change |
|------|--------|
| `PageLayout.tsx` | Theme-aware butterfly logic |
| `QuizPage.tsx` | `background="theme"` instead of hardcoded butterfly |
| `WelcomePage.tsx` | `background="theme"` instead of hardcoded butterfly |
| `ThankYouPage.tsx` | `background="theme"` instead of hardcoded butterfly |
| `ThemeTab.tsx` | Button spacing + reorganized layout |
| `Step3_Theme.tsx` | Inline hex gradients + unified card style |

## Testing

- [ ] Create event with princess theme → butterflies should appear
- [ ] Create event with dark theme (Nocturne Elegance) → NO butterflies
- [ ] Create event with other themes → NO butterflies
- [ ] Admin ThemeTab → buttons have visible gap between them
- [ ] Wizard Step3 → theme colors match Admin ThemeTab
- [ ] TypeScript check passes (`tsc --noEmit`)