### PR TITLE
fix(theme): improve dark theme contrast across admin and question editor

### DIFF
--- a/frontend/src/features/admin/components/ImportExportPanel.tsx
+++ b/frontend/src/features/admin/components/ImportExportPanel.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Download, Upload, AlertTriangle, Check } from 'lucide-react';
 import { Button } from '@/shared';
+import type { PreviewTheme } from '@/themes';
 
 interface ImportResult {
   imported: number;
@@ -14,6 +15,7 @@ interface ImportExportPanelProps {
   isExporting?: boolean;
   isImporting?: boolean;
   questionCount: number;
+  theme: PreviewTheme;
 }
 
 export function ImportExportPanel({
@@ -22,7 +24,13 @@ export function ImportExportPanel({
   isExporting = false,
   isImporting = false,
   questionCount,
+  theme,
 }: ImportExportPanelProps) {
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const panelSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.8)';
+  const headingColor = theme.textColor;
+  const mutedText = isDarkTheme ? 'rgba(226, 232, 240, 0.72)' : 'rgba(156, 163, 175, 1)';
+
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
 
@@ -52,8 +60,8 @@ export function ImportExportPanel({
   };
 
   return (
-    <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4">
-      <h3 className="font-display text-gray-700 mb-4">Importar / Exportar</h3>
+    <div className="backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4" style={{ backgroundColor: panelSurface }}>
+      <h3 className="font-display mb-4" style={{ color: headingColor }}>Importar / Exportar</h3>
 
       <div className="flex flex-wrap gap-3">
         {/* Export Button */}
@@ -130,7 +138,7 @@ export function ImportExportPanel({
         )}
       </AnimatePresence>
 
-      <p className="text-xs text-gray-400 mt-3">
+      <p className="text-xs mt-3" style={{ color: mutedText }}>
         Formato: JSON array de preguntas. Las preguntas existentes no se sobrescriben.
       </p>
     </div>

--- a/frontend/src/features/admin/components/QuestionForm.tsx
+++ b/frontend/src/features/admin/components/QuestionForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Plus, X, Save, ArrowLeft } from 'lucide-react';
 import { Button } from '@/shared';
+import type { PreviewTheme } from '@/themes';
 import type { 
   QuizQuestion, 
   QuestionFormData, 
@@ -18,6 +19,7 @@ interface QuestionFormProps {
   onSubmit: (data: QuestionFormData) => void;
   onCancel: () => void;
   onChange?: (data: QuestionFormData) => void; // NEW - for preview
+  theme: PreviewTheme;
 }
 
 export function QuestionForm({
@@ -27,7 +29,15 @@ export function QuestionForm({
   onSubmit,
   onCancel,
   onChange,
+  theme,
 }: QuestionFormProps) {
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const panelSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.8)';
+  const textColor = theme.textColor;
+  const mutedText = isDarkTheme ? 'rgba(226, 232, 240, 0.76)' : 'rgba(55, 65, 81, 1)';
+  const subtleText = isDarkTheme ? 'rgba(226, 232, 240, 0.62)' : 'rgba(156, 163, 175, 1)';
+  const fieldBorder = isDarkTheme ? 'rgba(148, 163, 184, 0.28)' : 'rgba(229, 231, 235, 1)';
+
   const [formData, setFormData] = useState<QuestionFormData>(INITIAL_QUESTION_FORM);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -162,15 +172,16 @@ export function QuestionForm({
   const showCorrectAnswers = formData.is_scorable;
 
   return (
-    <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4">
+    <div className="backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4" style={{ backgroundColor: panelSurface }}>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-display text-gray-800">
+        <h2 className="text-lg font-display" style={{ color: textColor }}>
           {question ? 'Editar Pregunta' : 'Nueva Pregunta'}
         </h2>
         {question && (
           <button
             onClick={onCancel}
-            className="p-1.5 rounded-lg text-gray-500 hover:bg-gray-100 transition-colors"
+            className="p-1.5 rounded-lg transition-colors"
+            style={{ color: mutedText }}
           >
             <ArrowLeft size={18} />
           </button>
@@ -180,7 +191,7 @@ export function QuestionForm({
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Key */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium mb-1" style={{ color: mutedText }}>
             Clave única
           </label>
           <input
@@ -195,26 +206,28 @@ export function QuestionForm({
               focus:outline-none transition-colors
               ${errors.key 
                 ? 'border-red-400 focus:border-red-500' 
-                : 'border-gray-200 focus:border-primary'
-              }
-            `}
-          />
+                 : 'focus:border-primary'
+               }
+             `}
+             style={!errors.key ? { borderColor: fieldBorder, color: textColor } : { color: textColor }}
+           />
           {errors.key && <p className="text-red-500 text-xs mt-1">{errors.key}</p>}
-          <p className="text-gray-400 text-[10px] mt-0.5">
+          <p className="text-[10px] mt-0.5" style={{ color: subtleText }}>
             Identificador único (sin espacios)
           </p>
         </div>
 
         {/* Section */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium mb-1" style={{ color: mutedText }}>
             Sección
           </label>
           <select
             value={formData.section}
             onChange={(e) => handleChange('section', e.target.value as QuestionSection)}
-            className="w-full px-3 py-2 bg-transparent border-b-2 border-gray-200 
+            className="w-full px-3 py-2 bg-transparent border-b-2 
                        focus:border-primary rounded-b-lg focus:outline-none text-sm"
+            style={{ borderColor: fieldBorder, color: textColor }}
           >
             <option value="favorites">Favoritos</option>
             <option value="preferences">Preferencias</option>
@@ -224,7 +237,7 @@ export function QuestionForm({
 
         {/* Question Text */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label className="block text-sm font-medium mb-1" style={{ color: mutedText }}>
             Pregunta
           </label>
           <textarea
@@ -239,10 +252,11 @@ export function QuestionForm({
               focus:outline-none transition-colors resize-none
               ${errors.question_text 
                 ? 'border-red-400 focus:border-red-500' 
-                : 'border-gray-200 focus:border-primary'
-              }
-            `}
-          />
+                 : 'focus:border-primary'
+               }
+             `}
+             style={!errors.question_text ? { borderColor: fieldBorder, color: textColor } : { color: textColor }}
+           />
           {errors.question_text && <p className="text-red-500 text-xs mt-1">{errors.question_text}</p>}
         </div>
 
@@ -264,7 +278,7 @@ export function QuestionForm({
             }}
             className="w-4 h-4 text-primary rounded border-gray-300 focus:ring-primary"
           />
-          <label htmlFor="is_choice" className="text-sm text-gray-700 cursor-pointer">
+          <label htmlFor="is_choice" className="text-sm cursor-pointer" style={{ color: mutedText }}>
             Opción múltiple (en lugar de texto libre)
           </label>
         </div>
@@ -278,7 +292,7 @@ export function QuestionForm({
               exit={{ opacity: 0, height: 0 }}
               className="space-y-2"
             >
-              <label className="block text-sm font-medium text-gray-700">
+              <label className="block text-sm font-medium" style={{ color: mutedText }}>
                 Opciones
               </label>
               {formData.options.map((option, index) => (
@@ -288,15 +302,17 @@ export function QuestionForm({
                     value={option}
                     onChange={(e) => handleOptionChange(index, e.target.value)}
                     placeholder={`Opción ${index + 1}`}
-                    className="flex-1 px-3 py-2 bg-transparent border-b-2 border-gray-200 
+                     className="flex-1 px-3 py-2 bg-transparent border-b-2 
                                focus:border-primary rounded-b-lg focus:outline-none text-sm"
-                  />
+                     style={{ borderColor: fieldBorder, color: textColor }}
+                   />
                   {formData.options.length > 2 && (
                     <button
                       type="button"
                       onClick={() => removeOption(index)}
-                      className="p-1.5 text-gray-400 hover:text-red-500 transition-colors"
-                    >
+                       className="p-1.5 hover:text-red-500 transition-colors"
+                       style={{ color: subtleText }}
+                     >
                       <X size={16} />
                     </button>
                   )}

--- a/frontend/src/features/admin/components/QuestionList.tsx
+++ b/frontend/src/features/admin/components/QuestionList.tsx
@@ -18,6 +18,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { motion, AnimatePresence } from 'framer-motion';
 import { GripVertical, Pencil, Trash2 } from 'lucide-react';
+import type { PreviewTheme } from '@/themes';
 import type { QuizQuestion, QuestionSection } from '../types/questions.types';
 import { SECTION_LABELS } from '../types/questions.types';
 import { groupQuestionsBySection } from '../hooks/useQuestionEditor';
@@ -28,6 +29,7 @@ interface QuestionListProps {
   onEdit: (question: QuizQuestion) => void;
   onDelete: (id: string) => void;
   deletingId?: string | null;
+  theme: PreviewTheme;
 }
 
 // Sortable wrapper component
@@ -36,12 +38,18 @@ function SortableQuestionItem({
   onEdit,
   onDelete,
   isDeleting,
+  theme,
 }: {
   question: QuizQuestion;
   onEdit: (q: QuizQuestion) => void;
   onDelete: (id: string) => void;
   isDeleting: boolean;
+  theme: PreviewTheme;
 }) {
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const itemSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.8)';
+  const mutedText = isDarkTheme ? 'rgba(226, 232, 240, 0.72)' : 'rgba(107, 114, 128, 1)';
+
   const {
     attributes,
     listeners,
@@ -66,13 +74,13 @@ function SortableQuestionItem({
   return (
     <motion.div
       ref={setNodeRef}
-      style={style}
+      style={{ ...style, backgroundColor: itemSurface }}
       layout
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, x: -20 }}
       className={`
-        relative bg-white/80 backdrop-blur-sm rounded-xl border border-[var(--color-secondary)]
+        relative backdrop-blur-sm rounded-xl border border-[var(--color-secondary)]
         shadow-sm hover:shadow-md transition-shadow p-3
         ${isDragging ? 'ring-2 ring-[var(--color-primary)] shadow-lg z-50' : ''}
         ${isDeleting ? 'opacity-50' : ''}
@@ -81,7 +89,8 @@ function SortableQuestionItem({
       <div className="flex items-center gap-3">
         {/* Drag Handle */}
         <button
-          className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 p-1"
+          className="cursor-grab active:cursor-grabbing p-1"
+          style={{ color: mutedText }}
           {...attributes}
           {...listeners}
         >
@@ -91,7 +100,7 @@ function SortableQuestionItem({
         {/* Content */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1">
-            <span className="text-xs font-mono text-gray-500">#{question.sort_order}</span>
+            <span className="text-xs font-mono" style={{ color: mutedText }}>#{question.sort_order}</span>
             <span className={`text-[10px] px-2 py-0.5 rounded-full font-medium ${questionType === 'choice' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
               {typeLabels[questionType]}
             </span>
@@ -101,10 +110,10 @@ function SortableQuestionItem({
               </span>
             )}
           </div>
-          <p className="text-sm font-medium text-gray-800 truncate">
+          <p className="text-sm font-medium truncate" style={{ color: theme.textColor }}>
             {question.question_text}
           </p>
-          <p className="text-xs text-gray-500 font-mono mt-0.5 truncate">
+          <p className="text-xs font-mono mt-0.5 truncate" style={{ color: mutedText }}>
             {question.key}
           </p>
         </div>
@@ -113,7 +122,8 @@ function SortableQuestionItem({
         <div className="flex items-center gap-1">
           <button
             onClick={() => onEdit(question)}
-            className="p-2 rounded-lg text-gray-500 hover:text-[var(--color-primary)] hover:bg-[color-mix(in_srgb,var(--color-primary)_8%,transparent)] transition-colors"
+            className="p-2 rounded-lg hover:text-[var(--color-primary)] hover:bg-[color-mix(in_srgb,var(--color-primary)_8%,transparent)] transition-colors"
+            style={{ color: mutedText }}
             title="Editar"
           >
             <Pencil size={16} />
@@ -121,7 +131,8 @@ function SortableQuestionItem({
           <button
             onClick={() => onDelete(question.id)}
             disabled={isDeleting}
-            className="p-2 rounded-lg text-gray-500 hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+            className="p-2 rounded-lg hover:text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+            style={{ color: mutedText }}
             title="Eliminar"
           >
             <Trash2 size={16} />
@@ -139,23 +150,29 @@ function QuestionSectionGroup({
   onEdit,
   onDelete,
   deletingId,
+  theme,
 }: {
   section: QuestionSection;
   questions: QuizQuestion[];
   onEdit: (q: QuizQuestion) => void;
   onDelete: (id: string) => void;
   deletingId: string | null;
+  theme: PreviewTheme;
 }) {
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const mutedText = isDarkTheme ? 'rgba(226, 232, 240, 0.72)' : 'rgba(75, 85, 99, 1)';
+  const dividerColor = isDarkTheme ? 'rgba(148, 163, 184, 0.22)' : 'rgba(229, 231, 235, 1)';
+
   if (questions.length === 0) return null;
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 px-1">
-        <h3 className="text-sm font-semibold text-gray-600 uppercase tracking-wider">
+        <h3 className="text-sm font-semibold uppercase tracking-wider" style={{ color: mutedText }}>
           {SECTION_LABELS[section]}
         </h3>
-        <div className="flex-1 h-px bg-gray-200" />
-        <span className="text-xs text-gray-400">{questions.length}</span>
+        <div className="flex-1 h-px" style={{ backgroundColor: dividerColor }} />
+        <span className="text-xs" style={{ color: mutedText }}>{questions.length}</span>
       </div>
       <div className="space-y-2">
         <AnimatePresence mode="popLayout">
@@ -166,6 +183,7 @@ function QuestionSectionGroup({
               onEdit={onEdit}
               onDelete={onDelete}
               isDeleting={deletingId === question.id}
+              theme={theme}
             />
           ))}
         </AnimatePresence>
@@ -180,6 +198,7 @@ export function QuestionList({
   onEdit,
   onDelete,
   deletingId = null,
+  theme,
 }: QuestionListProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -218,11 +237,15 @@ export function QuestionList({
   );
 
   if (questions.length === 0) {
+    const emptyMutedText = theme.backgroundStyle === 'dark'
+      ? 'rgba(226, 232, 240, 0.72)'
+      : 'color-mix(in srgb, var(--color-text) 70%, transparent)';
+
     return (
       <div className="text-center py-12 px-4">
         <div className="text-4xl mb-3">📝</div>
-        <p className="text-gray-500 font-medium">No hay preguntas todavía</p>
-        <p className="text-gray-400 text-sm mt-1">
+        <p className="font-medium" style={{ color: 'var(--color-text)' }}>No hay preguntas todavía</p>
+        <p className="text-sm mt-1" style={{ color: emptyMutedText }}>
           Crea tu primera pregunta usando el formulario de la derecha
         </p>
       </div>
@@ -244,6 +267,7 @@ export function QuestionList({
             onEdit={onEdit}
             onDelete={onDelete}
             deletingId={deletingId}
+            theme={theme}
           />
           <QuestionSectionGroup
             section="preferences"
@@ -251,6 +275,7 @@ export function QuestionList({
             onEdit={onEdit}
             onDelete={onDelete}
             deletingId={deletingId}
+            theme={theme}
           />
           <QuestionSectionGroup
             section="description"
@@ -258,6 +283,7 @@ export function QuestionList({
             onEdit={onEdit}
             onDelete={onDelete}
             deletingId={deletingId}
+            theme={theme}
           />
         </div>
       </SortableContext>

--- a/frontend/src/features/admin/components/QuestionPreview.tsx
+++ b/frontend/src/features/admin/components/QuestionPreview.tsx
@@ -1,13 +1,16 @@
 import { motion } from 'framer-motion';
 import { Eye } from 'lucide-react';
+import type { PreviewTheme } from '@/themes';
 import type { QuestionFormData } from '../types/questions.types';
 import { SECTION_LABELS } from '../types/questions.types';
 
 interface QuestionPreviewProps {
   data: QuestionFormData;
+  theme: PreviewTheme;
 }
 
-export function QuestionPreview({ data }: QuestionPreviewProps) {
+export function QuestionPreview({ data, theme }: QuestionPreviewProps) {
+  const isDarkTheme = theme.backgroundStyle === 'dark';
   const isChoice = data.options.length > 0;
   
   const bgGradient = isChoice 
@@ -15,10 +18,10 @@ export function QuestionPreview({ data }: QuestionPreviewProps) {
     : 'from-blue-50 to-blue-100';
 
   return (
-    <div className="bg-white/80 backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4">
+    <div className="backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-4" style={{ backgroundColor: isDarkTheme ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.8)' }}>
       <div className="flex items-center gap-2 mb-3">
-        <Eye size={16} className="text-gray-400" />
-        <h3 className="font-display text-gray-700 text-sm">Preview</h3>
+        <Eye size={16} style={{ color: 'color-mix(in srgb, var(--color-text) 65%, transparent)' }} />
+        <h3 className="font-display text-sm" style={{ color: theme.textColor }}>Preview</h3>
       </div>
 
       <motion.div
@@ -31,14 +34,14 @@ export function QuestionPreview({ data }: QuestionPreviewProps) {
         `}
       >
         {/* Question */}
-        <p className="font-medium text-gray-800 mb-3">
+        <p className="font-medium mb-3" style={{ color: theme.textColor }}>
           {data.question_text || 'Escribe tu pregunta...'}
         </p>
 
         {/* Input type preview */}
         {!isChoice && (
-          <div className="bg-white/60 rounded-lg px-3 py-2 border border-gray-200/50">
-            <span className="text-gray-400 text-sm">Tu respuesta aquí</span>
+          <div className="rounded-lg px-3 py-2 border" style={{ backgroundColor: isDarkTheme ? 'rgba(15, 23, 42, 0.54)' : 'rgba(255,255,255,0.6)', borderColor: isDarkTheme ? 'rgba(148, 163, 184, 0.18)' : 'rgba(229,231,235,0.5)' }}>
+            <span className="text-sm" style={{ color: 'color-mix(in srgb, var(--color-text) 60%, transparent)' }}>Tu respuesta aquí</span>
           </div>
         )}
 
@@ -49,15 +52,16 @@ export function QuestionPreview({ data }: QuestionPreviewProps) {
                 key={index}
                 className={`
                   flex items-center gap-3 px-3 py-2 rounded-lg
-                  bg-white/60 border border-gray-200/50
-                  ${data.correct_answers.includes(option) ? 'ring-2 ring-green-400' : ''}
-                `}
-              >
-                <div className="w-4 h-4 rounded-full border-2 border-gray-300" />
-                <span className="text-sm text-gray-700">{option || `Opción ${index + 1}`}</span>
-                {data.correct_answers.includes(option) && (
-                  <span className="ml-auto text-green-600 text-xs">✓</span>
-                )}
+                   border
+                   ${data.correct_answers.includes(option) ? 'ring-2 ring-green-400' : ''}
+                 `}
+                 style={{ backgroundColor: isDarkTheme ? 'rgba(15, 23, 42, 0.54)' : 'rgba(255,255,255,0.6)', borderColor: isDarkTheme ? 'rgba(148, 163, 184, 0.18)' : 'rgba(229,231,235,0.5)' }}
+               >
+                 <div className="w-4 h-4 rounded-full border-2" style={{ borderColor: isDarkTheme ? 'rgba(148, 163, 184, 0.5)' : 'rgba(209,213,219,1)' }} />
+                 <span className="text-sm" style={{ color: theme.textColor }}>{option || `Opción ${index + 1}`}</span>
+                 {data.correct_answers.includes(option) && (
+                   <span className="ml-auto text-green-600 text-xs">✓</span>
+                 )}
               </div>
             ))}
           </div>
@@ -65,8 +69,8 @@ export function QuestionPreview({ data }: QuestionPreviewProps) {
       </motion.div>
 
       {/* Metadata */}
-      <div className="flex items-center gap-2 mt-3 text-xs text-gray-400">
-        <span className="px-2 py-0.5 bg-gray-100 rounded">
+      <div className="flex items-center gap-2 mt-3 text-xs" style={{ color: 'color-mix(in srgb, var(--color-text) 65%, transparent)' }}>
+        <span className="px-2 py-0.5 rounded" style={{ backgroundColor: isDarkTheme ? 'rgba(30, 41, 59, 0.9)' : 'rgba(243,244,246,1)' }}>
           {isChoice ? 'Opción múltiple' : 'Texto'}
         </span>
         <span>•</span>

--- a/frontend/src/features/admin/pages/QuestionEditorPage.tsx
+++ b/frontend/src/features/admin/pages/QuestionEditorPage.tsx
@@ -1,20 +1,24 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ArrowLeft, Trash2, AlertTriangle } from 'lucide-react';
 import { Button } from '@/shared';
 import { useQuestionEditor } from '../hooks/useQuestionEditor';
 import { useTheme } from '@/shared/theme/useTheme';
+import { useEventAdmin } from '@/features/event-admin/hooks/useEventAdmin';
+import { getPresetByName, createTheme, applyCSSVariables } from '@/shared/theme';
 import { QuestionList } from '../components/QuestionList';
 import { QuestionForm } from '../components/QuestionForm';
 import { QuestionPreview } from '../components/QuestionPreview';
 import { ImportExportPanel } from '../components/ImportExportPanel';
+import type { PreviewTheme } from '@/themes';
 import type { QuizQuestion, QuestionFormData, QuestionSection } from '../types/questions.types';
 
 export function QuestionEditorPage() {
   const navigate = useNavigate();
   const { slug: eventSlug } = useParams<{ slug: string }>();
   const { currentTheme } = useTheme();
+  const { event } = useEventAdmin(eventSlug ?? '');
 
   const [selectedQuestion, setSelectedQuestion] = useState<QuizQuestion | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
@@ -34,6 +38,58 @@ export function QuestionEditorPage() {
 
   const isSubmitting = createMutation.isPending || updateMutation.isPending;
   const deletingId = deleteMutation.isPending ? showDeleteConfirm : null;
+
+  useEffect(() => {
+    const themeId = event?.settings?.theme;
+    if (!themeId) return;
+
+    const preset = getPresetByName(themeId);
+    if (!preset) return;
+
+    const completeTheme = createTheme({
+      primaryColor: preset.primaryColor,
+      secondaryColor: preset.secondaryColor,
+      accentColor: preset.accentColor,
+      bgColor: preset.bgColor,
+      textColor: preset.textColor,
+      displayFont: preset.displayFont,
+      headingFont: preset.headingFont,
+      bodyFont: preset.bodyFont,
+      backgroundStyle: preset.backgroundStyle,
+    });
+
+    return applyCSSVariables(completeTheme);
+  }, [event?.settings?.theme]);
+
+  const editorThemeId = event?.settings?.theme;
+  const editorPreset = editorThemeId ? getPresetByName(editorThemeId) : null;
+  const editorTheme: PreviewTheme = editorPreset
+    ? {
+        bgColor: editorPreset.bgColor,
+        textColor: editorPreset.textColor,
+        primaryColor: editorPreset.primaryColor,
+        secondaryColor: editorPreset.secondaryColor,
+        accentColor: editorPreset.accentColor,
+        displayFont: editorPreset.displayFont,
+        headingFont: editorPreset.headingFont,
+        bodyFont: editorPreset.bodyFont,
+        backgroundStyle: editorPreset.backgroundStyle,
+      }
+    : {
+        primaryColor: currentTheme.primaryColor,
+        secondaryColor: currentTheme.secondaryColor,
+        accentColor: currentTheme.accentColor,
+        bgColor: currentTheme.bgColor,
+        textColor: currentTheme.textColor,
+        displayFont: currentTheme.displayFont,
+        headingFont: currentTheme.headingFont,
+        bodyFont: currentTheme.bodyFont,
+        backgroundStyle: currentTheme.backgroundStyle,
+      };
+  const isDarkTheme = editorTheme.backgroundStyle === 'dark';
+  const headerSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.84)' : 'rgba(255, 255, 255, 0.8)';
+  const panelSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.6)';
+  const mutedText = isDarkTheme ? 'rgba(226, 232, 240, 0.76)' : 'rgba(107, 114, 128, 1)';
 
   // Handle create/update
   const handleSubmit = async (data: QuestionFormData) => {
@@ -179,26 +235,29 @@ export function QuestionEditorPage() {
   return (
     <div 
       className="min-h-screen"
-      style={{ backgroundColor: currentTheme.bgColor }}
+      style={{ backgroundColor: editorTheme.bgColor }}
     >
       {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-[var(--color-secondary)] sticky top-0 z-10">
+      <header
+        className="backdrop-blur-sm border-b border-[var(--color-secondary)] sticky top-0 z-10"
+        style={{ backgroundColor: headerSurface }}
+      >
         <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <button
               onClick={() => navigate(-1)}
               className="p-2 rounded-lg hover:bg-[color-mix(in_srgb,var(--color-primary)_8%,transparent)] transition-colors"
             >
-              <ArrowLeft size={20} className="text-gray-600" />
+              <ArrowLeft size={20} style={{ color: editorTheme.textColor }} />
             </button>
             <div>
-              <h1 className="font-display text-xl text-gray-800">
+              <h1 className="font-display text-xl" style={{ color: editorTheme.textColor }}>
                 Editor de Preguntas
               </h1>
-              <p className="text-xs text-gray-500">{eventSlug}</p>
+              <p className="text-xs" style={{ color: mutedText }}>{eventSlug}</p>
             </div>
           </div>
-          <div className="text-sm text-gray-500">
+          <div className="text-sm" style={{ color: mutedText }}>
             {questions.length} pregunta{questions.length !== 1 ? 's' : ''}
           </div>
         </div>
@@ -214,6 +273,7 @@ export function QuestionEditorPage() {
               onEdit={handleEdit}
               onDelete={handleDelete}
               deletingId={deletingId}
+              theme={editorTheme}
             />
 
             {/* Import/Export */}
@@ -222,6 +282,7 @@ export function QuestionEditorPage() {
               onImport={handleImport}
               isImporting={importMutation.isPending}
               questionCount={questions.length}
+              theme={editorTheme}
             />
           </div>
 
@@ -242,6 +303,7 @@ export function QuestionEditorPage() {
                     onSubmit={handleSubmit}
                     onCancel={handleCancelForm}
                     onChange={setFormData}
+                    theme={editorTheme}
                   />
                   <div className="mt-4">
                     <QuestionPreview data={formData || {
@@ -251,7 +313,7 @@ export function QuestionEditorPage() {
                       options: selectedQuestion?.options || ['', ''],
                       correct_answers: selectedQuestion?.correct_answers || [],
                       is_scorable: selectedQuestion?.is_scorable ?? true,
-                    }} />
+                    }} theme={editorTheme} />
                   </div>
                 </motion.div>
               ) : (
@@ -259,13 +321,14 @@ export function QuestionEditorPage() {
                   key="empty"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 1 }}
-                  className="bg-white/60 backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-6 text-center"
+                  className="backdrop-blur-sm rounded-2xl border border-[var(--color-secondary)] p-6 text-center"
+                  style={{ backgroundColor: panelSurface }}
                 >
                   <div className="text-4xl mb-3">✏️</div>
-                  <p className="text-gray-600 font-medium">
+                  <p className="font-medium" style={{ color: editorTheme.textColor }}>
                     Crear nueva pregunta
                   </p>
-                  <p className="text-gray-400 text-sm mt-1">
+                  <p className="text-sm mt-1" style={{ color: mutedText }}>
                     Completa el formulario para agregar una pregunta al quiz
                   </p>
                   <div className="mt-4 flex flex-col gap-2">

--- a/frontend/src/features/event-admin/components/ConfigTab.tsx
+++ b/frontend/src/features/event-admin/components/ConfigTab.tsx
@@ -21,6 +21,9 @@ export function ConfigTab({ slug, previewTheme }: ConfigTabProps) {
   
   // Use preview theme colors if provided, otherwise use the event's current theme
   const theme = previewTheme || currentTheme;
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const floatingButtonSurface = isDarkTheme ? 'rgba(15, 23, 42, 0.9)' : 'rgba(255, 255, 255, 0.9)';
+  const floatingButtonHoverSurface = isDarkTheme ? 'rgba(30, 41, 59, 0.96)' : '#FFFFFF';
   const [features, setFeatures] = useState<EventFeatures>({
     quiz: true,
     corkboard: true,
@@ -240,7 +243,14 @@ export function ConfigTab({ slug, previewTheme }: ConfigTabProps) {
               <button
                 onClick={() => logoInputRef.current?.click()}
                 disabled={isUploadingLogo}
-                className="p-2 bg-white/90 hover:bg-white rounded-full shadow-md transition-all hover:scale-105 disabled:opacity-50"
+                className="p-2 rounded-full shadow-md transition-all hover:scale-105 disabled:opacity-50"
+                style={{ backgroundColor: floatingButtonSurface }}
+                onMouseEnter={(e) => {
+                  e.currentTarget.style.backgroundColor = floatingButtonHoverSurface;
+                }}
+                onMouseLeave={(e) => {
+                  e.currentTarget.style.backgroundColor = floatingButtonSurface;
+                }}
                 title="Subir logo"
               >
                 {isUploadingLogo ? (
@@ -253,7 +263,14 @@ export function ConfigTab({ slug, previewTheme }: ConfigTabProps) {
                 <button
                   onClick={handleDeleteLogo}
                   disabled={isUploadingLogo}
-                  className="p-2 bg-white/90 hover:bg-white rounded-full shadow-md transition-all hover:scale-105 disabled:opacity-50"
+                  className="p-2 rounded-full shadow-md transition-all hover:scale-105 disabled:opacity-50"
+                  style={{ backgroundColor: floatingButtonSurface }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.backgroundColor = floatingButtonHoverSurface;
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.backgroundColor = floatingButtonSurface;
+                  }}
                   title="Eliminar logo"
                 >
                   {isUploadingLogo ? (

--- a/frontend/src/features/event-admin/components/ThemeTab.tsx
+++ b/frontend/src/features/event-admin/components/ThemeTab.tsx
@@ -28,7 +28,12 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
     accentColor: '#DB2777',
     bgColor: '#FFF5F7',
     textColor: '#1E293B',
+    backgroundStyle: 'watercolor',
   };
+  const isDarkTheme = theme.backgroundStyle === 'dark';
+  const secondaryButtonBg = isDarkTheme ? 'rgba(15, 23, 42, 0.92)' : theme.secondaryColor;
+  const secondaryButtonText = isDarkTheme ? theme.textColor : (theme.accentColor || theme.primaryColor);
+  const secondaryButtonBorder = isDarkTheme ? 'rgba(103, 232, 249, 0.35)' : `${theme.primaryColor}30`;
 
   // Get current theme from event settings (backend stores preset name in settings.theme)
   const currentThemeId = event?.settings?.theme || null;
@@ -211,9 +216,9 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
               fullWidth
               icon={<Palette className="w-4 h-4" />}
               style={{ 
-                backgroundColor: theme.secondaryColor,
-                color: theme.accentColor || theme.primaryColor,
-                border: `1px solid ${theme.primaryColor}30`
+                backgroundColor: secondaryButtonBg,
+                color: secondaryButtonText,
+                border: `1px solid ${secondaryButtonBorder}`
               }}
             >
               Personalizar Tema
@@ -230,9 +235,9 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
             fullWidth
             icon={<Palette className="w-4 h-4" />}
             style={{ 
-              backgroundColor: theme.secondaryColor,
-              color: theme.accentColor || theme.primaryColor,
-              border: `1px solid ${theme.primaryColor}30`
+              backgroundColor: secondaryButtonBg,
+              color: secondaryButtonText,
+              border: `1px solid ${secondaryButtonBorder}`
             }}
           >
             Personalizar Tema
@@ -257,5 +262,3 @@ export function ThemeTab({ slug, onPreview, onSave, previewTheme }: ThemeTabProp
     </div>
   );
 }
-
-

--- a/frontend/src/features/event-admin/pages/EventAdminPage.tsx
+++ b/frontend/src/features/event-admin/pages/EventAdminPage.tsx
@@ -1,5 +1,5 @@
 import { useSearchParams, useNavigate, useParams } from 'react-router-dom';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { ArrowLeft, Settings, MessageSquare, Palette, BarChart3, TrendingUp, Eye, Camera } from 'lucide-react';
 import { useEventAdmin, type AdminTab } from '../hooks/useEventAdmin';
@@ -12,7 +12,7 @@ import { StatsTab } from '../components/StatsTab';
 import { AnalyticsDashboard } from '@/features/analytics/pages/AnalyticsDashboard';
 import { Skeleton } from '@/shared/components/Skeleton';
 import { api } from '@/shared/lib/api';
-import { getPresetByName } from '@/shared/theme';
+import { getPresetByName, createTheme, applyCSSVariables } from '@/shared/theme';
 import type { PreviewTheme } from '@/themes';
 
 const TABS: { id: AdminTab; label: string; icon: React.ReactNode }[] = [
@@ -47,8 +47,17 @@ export function EventAdminPage() {
   // Preview theme state - allows immediate theme preview without saving
   const [previewTheme, setPreviewTheme] = useState<PreviewTheme>(defaultAdminTheme);
   const [showPreviewBadge, setShowPreviewBadge] = useState(false);
+  const themeCleanupRef = useRef<(() => void) | null>(null);
 
   const currentTab: AdminTab = TABS.find((t) => t.id === tabParam)?.id ?? 'config';
+  const isDarkPreview = previewTheme.backgroundStyle === 'dark';
+  const chromeSurface = isDarkPreview ? 'rgba(15, 23, 42, 0.82)' : 'rgba(255, 255, 255, 0.8)';
+  const chromeBorder = isDarkPreview ? 'rgba(148, 163, 184, 0.18)' : `${previewTheme.secondaryColor}50`;
+  const panelSurface = isDarkPreview ? 'rgba(15, 23, 42, 0.88)' : 'rgba(255, 255, 255, 0.8)';
+  const panelBorder = isDarkPreview ? 'rgba(148, 163, 184, 0.14)' : 'rgba(255, 255, 255, 0.5)';
+  const tabRailSurface = isDarkPreview ? 'rgba(30, 41, 59, 0.76)' : `${previewTheme.secondaryColor}30`;
+  const activeTabSurface = isDarkPreview ? 'rgba(15, 23, 42, 0.96)' : '#FFFFFF';
+  const mutedText = isDarkPreview ? 'rgba(226, 232, 240, 0.78)' : `${previewTheme.textColor}80`;
 
   const { event, isLoadingEvent, errorEvent, refetchEvent } = useEventAdmin(slug);
 
@@ -57,16 +66,19 @@ export function EventAdminPage() {
 
   // Apply theme to CSS variables for preview
   const applyThemeToCSS = useCallback((theme: PreviewTheme) => {
-    const root = document.documentElement;
-    root.style.setProperty('--color-primary', theme.primaryColor);
-    root.style.setProperty('--color-secondary', theme.secondaryColor);
-    root.style.setProperty('--color-accent', theme.accentColor);
-    root.style.setProperty('--color-bg', theme.bgColor);
-    root.style.setProperty('--color-text', theme.textColor);
-    root.style.setProperty('--font-display', `'${theme.displayFont}', cursive`);
-    root.style.setProperty('--font-heading', `'${theme.headingFont}', serif`);
-    root.style.setProperty('--font-body', `'${theme.bodyFont}', sans-serif`);
-    document.body.className = `theme-${theme.backgroundStyle}`;
+    themeCleanupRef.current?.();
+    const completeTheme = createTheme({
+      primaryColor: theme.primaryColor,
+      secondaryColor: theme.secondaryColor,
+      accentColor: theme.accentColor,
+      bgColor: theme.bgColor,
+      textColor: theme.textColor,
+      displayFont: theme.displayFont,
+      headingFont: theme.headingFont,
+      bodyFont: theme.bodyFont,
+      backgroundStyle: theme.backgroundStyle,
+    });
+    themeCleanupRef.current = applyCSSVariables(completeTheme);
   }, []);
 
   // Initialize preview theme from event data when it loads
@@ -96,16 +108,8 @@ export function EventAdminPage() {
   // Cleanup CSS variables when leaving admin page
   useEffect(() => {
     return () => {
-      const root = document.documentElement;
-      root.style.removeProperty('--color-primary');
-      root.style.removeProperty('--color-secondary');
-      root.style.removeProperty('--color-accent');
-      root.style.removeProperty('--color-bg');
-      root.style.removeProperty('--color-text');
-      root.style.removeProperty('--font-display');
-      root.style.removeProperty('--font-heading');
-      root.style.removeProperty('--font-body');
-      document.body.className = '';
+      themeCleanupRef.current?.();
+      themeCleanupRef.current = null;
     };
   }, []);
 
@@ -114,17 +118,8 @@ export function EventAdminPage() {
   };
 
   const handleBack = () => {
-    // Reset CSS variables before leaving
-    const root = document.documentElement;
-    root.style.removeProperty('--color-primary');
-    root.style.removeProperty('--color-secondary');
-    root.style.removeProperty('--color-accent');
-    root.style.removeProperty('--color-bg');
-    root.style.removeProperty('--color-text');
-    root.style.removeProperty('--font-display');
-    root.style.removeProperty('--font-heading');
-    root.style.removeProperty('--font-body');
-    document.body.className = '';
+    themeCleanupRef.current?.();
+    themeCleanupRef.current = null;
     navigate('/dashboard');
   };
 
@@ -184,13 +179,13 @@ export function EventAdminPage() {
         </motion.div>
       )}
 
-      <header 
-        className="backdrop-blur-sm border-b sticky top-0 z-10"
-        style={{ 
-          backgroundColor: 'rgba(255, 255, 255, 0.8)',
-          borderColor: `${previewTheme.secondaryColor}50`
-        }}
-      >
+        <header 
+          className="backdrop-blur-sm border-b sticky top-0 z-10"
+          style={{ 
+            backgroundColor: chromeSurface,
+            borderColor: chromeBorder
+          }}
+        >
         <div className="max-w-2xl mx-auto px-4 py-3">
           <div className="flex items-center gap-3">
             <button
@@ -232,7 +227,7 @@ export function EventAdminPage() {
                         </span>
                       )}
                     </div>
-                    <p className="text-xs" style={{ color: `${previewTheme.textColor}80` }}>
+                    <p className="text-xs" style={{ color: mutedText }}>
                       Panel de administración
                     </p>
                   </>
@@ -248,13 +243,13 @@ export function EventAdminPage() {
           animate={{ opacity: 1, y: 0 }}
           className="backdrop-blur-sm rounded-3xl shadow-xl border p-6"
           style={{ 
-            backgroundColor: 'rgba(255, 255, 255, 0.8)',
-            borderColor: 'rgba(255, 255, 255, 0.5)'
+            backgroundColor: panelSurface,
+            borderColor: panelBorder
           }}
         >
           <nav 
             className="flex gap-1 mb-6 p-1 rounded-xl"
-            style={{ backgroundColor: `${previewTheme.secondaryColor}30` }}
+            style={{ backgroundColor: tabRailSurface }}
           >
             {visibleTabs.map((tab) => {
               const isActive = currentTab === tab.id;
@@ -267,8 +262,8 @@ export function EventAdminPage() {
                     ${isActive ? 'shadow-sm' : ''}
                   `}
                   style={{ 
-                    backgroundColor: isActive ? '#FFFFFF' : 'transparent',
-                    color: isActive ? previewTheme.primaryColor : `${previewTheme.textColor}80`
+                    backgroundColor: isActive ? activeTabSurface : 'transparent',
+                    color: isActive ? previewTheme.primaryColor : mutedText
                   }}
                 >
                   {tab.icon}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -187,6 +187,13 @@ body {
   box-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
 }
 
+.theme-dark .sparkle-dot,
+.dark .sparkle-dot {
+  background: rgba(103, 232, 249, 0.75);
+  opacity: 0.45;
+  box-shadow: 0 0 10px rgba(103, 232, 249, 0.45);
+}
+
 /* Gradientes de texto */
 .text-gradient-primary {
   background-clip: text;
@@ -225,6 +232,13 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
 }
 
+.theme-dark .stitch-glass-header,
+.dark .stitch-glass-header {
+  background: rgba(15, 23, 42, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.38);
+}
+
 /* Stitch Bottom Navigation */
 .stitch-bottom-nav {
   position: fixed;
@@ -240,6 +254,13 @@ body {
   padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
 }
 
+.theme-dark .stitch-bottom-nav,
+.dark .stitch-bottom-nav {
+  background: rgba(15, 23, 42, 0.92);
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 -8px 24px rgba(2, 6, 23, 0.25);
+}
+
 /* Stitch Bento Card */
 .stitch-bento-card {
   border-radius: 2rem;
@@ -249,9 +270,21 @@ body {
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.theme-dark .stitch-bento-card,
+.dark .stitch-bento-card {
+  background: rgba(30, 41, 59, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: 0 12px 30px rgba(2, 6, 23, 0.32);
+}
+
 .stitch-bento-card:hover {
   transform: translateY(-4px);
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.1);
+}
+
+.theme-dark .stitch-bento-card:hover,
+.dark .stitch-bento-card:hover {
+  box-shadow: 0 16px 36px rgba(2, 6, 23, 0.42);
 }
 
 /* Stitch Primary Button */


### PR DESCRIPTION
## Summary
- improve dark theme contrast in the admin preview shell and shared stitch surfaces
- make the question editor inherit the full event theme token set instead of partial CSS vars
- pass the effective event theme through question editor child components so dark presets like Nocturne Elegance render legibly

## What changed
- Updated `EventAdminPage` to apply complete theme tokens via `createTheme(...)` + `applyCSSVariables(...)` instead of manually setting a few CSS vars.
- Added dark-theme overrides in `frontend/src/index.css` for:
  - `sparkle-dot`
  - `stitch-glass-header`
  - `stitch-bottom-nav`
  - `stitch-bento-card`
- Improved admin contrast in:
  - `ConfigTab.tsx`
  - `ThemeTab.tsx`
  - `EventAdminPage.tsx`
- Fixed `QuestionEditorPage` so it resolves the event preset and applies the full theme token set.
- Passed the effective editor theme into:
  - `ImportExportPanel`
  - `QuestionList`
  - `QuestionForm`
  - `QuestionPreview`
- Replaced several hardcoded light-only surfaces/text treatments with theme-aware styling inside the question editor flow.

## Why
The dark theme preview was applying only a partial subset of CSS variables, so shared components like outline buttons still used stale/default contrast tokens. In addition, question editor child components were reading theme context independently instead of the actual event preset being previewed, causing inconsistent contrast across dark presets such as Nocturne Elegance.

## Validation
- `npm run build` ✅

Closes #60