### PR TITLE
fix(i18n): wire up translations across landing, auth, and dashboard

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -15,65 +15,160 @@
     "search": "Search",
     "noResults": "No results",
     "required": "Required",
-    "optional": "Optional"
+    "optional": "Optional",
+    "rememberMe": "Remember me"
   },
   "auth": {
     "login": "Log in",
     "register": "Create account",
     "logout": "Log out",
     "email": "Email",
+    "name": "Full name",
     "password": "Password",
     "confirmPassword": "Confirm password",
     "forgotPassword": "Forgot password?",
     "noAccount": "Don't have an account?",
     "hasAccount": "Already have an account?",
     "loginError": "Login failed",
-    "registerSuccess": "Account created successfully"
+    "registerSuccess": "Account created successfully",
+    "nameRequired": "Name is required",
+    "minLength": "must be at least 6 characters",
+    "passwordsMismatch": "Passwords don't match",
+    "weak": "Weak",
+    "medium": "Medium",
+    "strong": "Strong"
+  },
+  "dashboard": {
+    "title": "My Events",
+    "eventsCount": "{{count}} event created",
+    "eventsCount_plural": "{{count}} events created",
+    "refresh": "Refresh",
+    "logout": "Log out",
+    "createEvent": "Create new event",
+    "empty": {
+      "title": "You don't have events yet",
+      "subtitle": "Create your first event and start organizing unique experiences for your guests.",
+      "cta": "Create your first event",
+      "tipsTitle": "What can you create?",
+      "tip1": "Birthday with interactive quiz",
+      "tip2": "Corporate events with boards",
+      "tip3": "Weddings with surprise box",
+      "tip4": "Any special celebration"
+    },
+    "error": {
+      "retry": "Retry"
+    }
+  },
+  "nav": {
+    "home": "Home",
+    "create": "Create",
+    "explore": "Explore",
+    "profile": "Profile",
+    "dashboard": "Dashboard"
   },
   "landing": {
     "hero": {
+      "tagline": "Interactive events platform",
       "title": "Create memorable experiences",
-      "subtitle": "The best platform for interactive events with quizzes, rankings and photo boards",
-      "cta": "Create my event",
-      "enterCode": "Enter event code"
+      "subtitle": "Organize unique events with interactive quizzes, photo boards and secret boxes. Everything in one place, easy to share.",
+      "createEvent": "Create Event",
+      "joinEvent": "Join Event",
+      "stats": {
+        "eventsCreated": "Events created",
+        "guestsPerEvent": "Guests per event",
+        "satisfaction": "Satisfaction"
+      }
     },
     "features": {
-      "title": "Everything you need",
+      "title": "Everything you need for your event",
+      "subtitle": "Interactive tools designed to make your celebration unique and memorable.",
+      "characteristics": "Features",
+      "includedAllPlans": "✓ Included in all plans",
       "quiz": {
-        "title": "Custom Quiz",
-        "description": "Create questions about the birthday person and discover who knows them best"
+        "title": "Interactive Quiz",
+        "description": "Custom questions to get to know the birthday person. Real-time ranking."
       },
       "corkboard": {
         "title": "Photo Board",
-        "description": "Your guests upload photos and messages in real-time"
+        "description": "Guests share photos and messages on a collaborative digital board."
       },
-      "secretBox": {
+      "secret": {
         "title": "Secret Box",
-        "description": "Receive surprises from those who can't be there"
-      },
-      "ranking": {
-        "title": "Live Ranking",
-        "description": "Friendly competition with 3D podium"
+        "description": "Surprises from remote guests that are revealed at the perfect moment."
       }
     },
     "pricing": {
-      "title": "Plans and pricing",
+      "title": "Simple and transparent",
+      "subtitle": "Start free, upgrade when you want",
+      "prices": "Pricing",
+      "mostPopular": "⭐ Most popular",
       "free": {
         "name": "Free",
-        "description": "Perfect for trying EventHub"
+        "description": "Perfect for trying EventHub with small events",
+        "price": "$0",
+        "priceSuffix": "free forever",
+        "cta": "Start free",
+        "features": {
+          "upTo20Guests": "Up to 20 guests per event",
+          "1ActiveEvent": "1 active event",
+          "basicQuiz": "Basic quiz (10 questions)",
+          "photoBoard": "Photo board",
+          "liveRanking": "Real-time ranking",
+          "basicAnalytics": "Basic analytics",
+          "secretBox": "Secret Box",
+          "videoPostcards": "Video postcards",
+          "prioritySupport": "Priority support",
+          "unlimitedEvents": "Unlimited events"
+        }
       },
       "premium": {
         "name": "Premium",
-        "price": "$4.99 USD",
-        "description": "For memorable events"
-      }
+        "description": "For memorable celebrations without limits",
+        "price": "$4.99",
+        "cta": "Unlock Premium",
+        "features": {
+          "unlimitedGuests": "Unlimited guests",
+          "unlimitedEvents": "Unlimited events",
+          "fullQuiz": "Full quiz (unlimited questions)",
+          "photoBoardVideos": "Photo board + videos",
+          "liveRanking": "Real-time ranking",
+          "advancedAnalytics": "Advanced analytics",
+          "secretBox": "Secret Box",
+          "videoPostcards": "Video postcards",
+          "prioritySupport": "Priority support",
+          "customThemes": "Custom themes"
+        }
+      },
+      "trustSignals": "No credit card required · Cancel whenever you want"
+    },
+    "joinSection": {
+      "title": "Join the celebration",
+      "subtitle": "Do you have an event code?",
+      "description": "Enter the code you received to join the celebration",
+      "placeholder": "Ex: birthday-ana-2026",
+      "search": "Search",
+      "searching": "Searching...",
+      "found": "Found!",
+      "noCode": "Don't have a code?",
+      "createOwnEvent": "Create your own event",
+      "helpText": "The code is the last part of the event URL",
+      "errorNoCode": "Enter an event code",
+      "errorNotFound": "Event not found. Check the code and try again.",
+      "errorConnection": "Connection error. Try again."
     },
     "footer": {
-      "about": "About",
+      "product": "Product",
+      "legal": "Legal",
+      "functions": "Features",
+      "demo": "Demo",
+      "faq": "FAQ",
+      "privacy": "Privacy Policy",
+      "terms": "Terms of Service",
       "contact": "Contact",
-      "privacy": "Privacy",
-      "terms": "Terms",
-      "madeWith": "Made with ❤️ for celebrations"
+      "about": "About us",
+      "rights": "All rights reserved.",
+      "madeWith": "Made with ❤️ for memorable celebrations",
+      "description": "Create memorable experiences for your celebrations. Interactive events with quizzes, photo boards, and secret boxes."
     }
   },
   "quiz": {

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -15,65 +15,160 @@
     "search": "Buscar",
     "noResults": "No hay resultados",
     "required": "Requerido",
-    "optional": "Opcional"
+    "optional": "Opcional",
+    "rememberMe": "Recordarme"
   },
   "auth": {
     "login": "Iniciar sesión",
     "register": "Crear cuenta",
     "logout": "Cerrar sesión",
     "email": "Email",
+    "name": "Nombre completo",
     "password": "Contraseña",
     "confirmPassword": "Confirmar contraseña",
     "forgotPassword": "¿Olvidaste tu contraseña?",
     "noAccount": "¿No tenés cuenta?",
     "hasAccount": "¿Ya tenés cuenta?",
     "loginError": "Error al iniciar sesión",
-    "registerSuccess": "Cuenta creada exitosamente"
+    "registerSuccess": "Cuenta creada exitosamente",
+    "nameRequired": "El nombre es requerido",
+    "minLength": "debe tener al menos 6 caracteres",
+    "passwordsMismatch": "Las contraseñas no coinciden",
+    "weak": "Débil",
+    "medium": "Media",
+    "strong": "Fuerte"
+  },
+  "dashboard": {
+    "title": "Mis Eventos",
+    "eventsCount": "{{count}} evento creado",
+    "eventsCount_plural": "{{count}} eventos creados",
+    "refresh": "Actualizar",
+    "logout": "Cerrar sesión",
+    "createEvent": "Crear nuevo evento",
+    "empty": {
+      "title": "No tenés eventos aún",
+      "subtitle": "Crea tu primer evento y comienza a organizar experiencias únicas para tus invitados.",
+      "cta": "Creá tu primer evento",
+      "tipsTitle": "¿Qué podés crear?",
+      "tip1": "Cumpleaños con quiz interactivo",
+      "tip2": "Eventos corporativos con carteleras",
+      "tip3": "Bodas con caja de sorpresas",
+      "tip4": "Cualquier celebración especial"
+    },
+    "error": {
+      "retry": "Reintentar"
+    }
+  },
+  "nav": {
+    "home": "Inicio",
+    "create": "Crear",
+    "explore": "Explorar",
+    "profile": "Perfil",
+    "dashboard": "Dashboard"
   },
   "landing": {
     "hero": {
+      "tagline": "Plataforma de eventos interactivos",
       "title": "Creá experiencias memorables",
-      "subtitle": "La mejor plataforma para crear eventos interactivos con quiz, ranking y carteleras de fotos",
-      "cta": "Crear mi evento",
-      "enterCode": "Ingresar código de evento"
+      "subtitle": "Organizá eventos únicos con quizzes interactivos, carteleras de fotos y cajas secretas. Todo en un solo lugar, fácil de compartir.",
+      "createEvent": "Crear Evento",
+      "joinEvent": "Ingresar a Evento",
+      "stats": {
+        "eventsCreated": "Eventos creados",
+        "guestsPerEvent": "Invitados por evento",
+        "satisfaction": "Satisfacción"
+      }
     },
     "features": {
-      "title": "Todo lo que necesitás",
+      "title": "Todo lo que necesitás para tu evento",
+      "subtitle": "Herramientas interactivas diseñadas para hacer tu celebración única y memorable.",
+      "characteristics": "Características",
+      "includedAllPlans": "✓ Incluido en todos los planes",
       "quiz": {
-        "title": "Quiz personalizado",
-        "description": "Creá preguntas sobre el festejado y descubrí quién lo conoce mejor"
+        "title": "Quiz Interactivo",
+        "description": "Preguntas personalizadas para conocer a tu cumpleañero/a. Ranking en tiempo real."
       },
       "corkboard": {
-        "title": "Cartelera de fotos",
-        "description": "Tus invitados suben fotos y mensajes en tiempo real"
+        "title": "Cartelera de Fotos",
+        "description": "Invitados comparten fotos y mensajes en un corcho digital colaborativo."
       },
-      "secretBox": {
-        "title": "Caja secreta",
-        "description": "Recibí sorpresas de quienes no pueden estar"
-      },
-      "ranking": {
-        "title": "Ranking en vivo",
-        "description": "Competencia amistosa con podium 3D"
+      "secret": {
+        "title": "Caja Secreta",
+        "description": "Sorpresas de invitados remotos que se revelan en el momento perfecto."
       }
     },
     "pricing": {
-      "title": "Planes y precios",
+      "title": "Simple y transparente",
+      "subtitle": "Empezá gratis, actualizá cuando quieras",
+      "prices": "Precios",
+      "mostPopular": "⭐ Más popular",
       "free": {
         "name": "Free",
-        "description": "Ideal para probar EventHub"
+        "description": "Ideal para probar EventHub con eventos pequeños",
+        "price": "$0",
+        "priceSuffix": "gratis para siempre",
+        "cta": "Empezar gratis",
+        "features": {
+          "upTo20Guests": "Hasta 20 invitados por evento",
+          "1ActiveEvent": "1 evento activo",
+          "basicQuiz": "Quiz básico (10 preguntas)",
+          "photoBoard": "Cartelera de fotos",
+          "liveRanking": "Ranking en tiempo real",
+          "basicAnalytics": "Analytics básicos",
+          "secretBox": "Caja Secreta",
+          "videoPostcards": "Videos en postal",
+          "prioritySupport": "Soporte prioritario",
+          "unlimitedEvents": "Eventos ilimitados"
+        }
       },
       "premium": {
         "name": "Premium",
-        "price": "$4.99 USD",
-        "description": "Para eventos memorables"
-      }
+        "description": "Para celebraciones memorables sin límites",
+        "price": "$4.99",
+        "cta": "Desbloquear Premium",
+        "features": {
+          "unlimitedGuests": "Invitados ilimitados",
+          "unlimitedEvents": "Eventos ilimitados",
+          "fullQuiz": "Quiz completo (preguntas ilimitadas)",
+          "photoBoardVideos": "Cartelera de fotos + videos",
+          "liveRanking": "Ranking en tiempo real",
+          "advancedAnalytics": "Analytics avanzados",
+          "secretBox": "Caja Secreta",
+          "videoPostcards": "Videos en postal",
+          "prioritySupport": "Soporte prioritario",
+          "customThemes": "Temas personalizados"
+        }
+      },
+      "trustSignals": "Sin tarjeta de crédito requerida · Cancela cuando quieras"
+    },
+    "joinSection": {
+      "title": "Unite a la celebración",
+      "subtitle": "¿Ya tenés un código de evento?",
+      "description": "Ingresá el código que recibiste para unirte a la celebración",
+      "placeholder": "Ej: cumple-ana-2026",
+      "search": "Buscar",
+      "searching": "Buscando...",
+      "found": "¡Encontrado!",
+      "noCode": "¿No tenés un código?",
+      "createOwnEvent": "Creá tu propio evento",
+      "helpText": "El código es la última parte de la URL del evento",
+      "errorNoCode": "Ingresá un código de evento",
+      "errorNotFound": "Evento no encontrado. Verificá el código e intentá de nuevo.",
+      "errorConnection": "Error de conexión. Intentá de nuevo."
     },
     "footer": {
-      "about": "Acerca de",
+      "product": "Producto",
+      "legal": "Legal",
+      "functions": "Funciones",
+      "demo": "Demo",
+      "faq": "FAQ",
+      "privacy": "Política de Privacidad",
+      "terms": "Términos de Servicio",
       "contact": "Contacto",
-      "privacy": "Privacidad",
-      "terms": "Términos",
-      "madeWith": "Hecho con ❤️ para celebraciones"
+      "about": "Sobre nosotros",
+      "rights": "Todos los derechos reservados.",
+      "madeWith": "Hecho con ❤️ para celebraciones memorables",
+      "description": "Creá experiencias memorables para tus celebraciones. Eventos interactivos con quizzes, carteleras de fotos y cajas secretas."
     }
   },
   "quiz": {

--- a/frontend/src/features/auth/pages/LoginPage.tsx
+++ b/frontend/src/features/auth/pages/LoginPage.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import { Eye, EyeOff, LogIn, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { Button } from '@/shared/components/Button';
 import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 
 export function LoginPage() {
+  const { t } = useTranslation();
   const { login, isLoading, error, clearError, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -35,14 +37,14 @@ export function LoginPage() {
 
     // Email validation
     if (!formData.email.trim()) {
-      errors.email = 'El email es requerido';
+      errors.email = t('auth.email') + ' ' + t('common.required').toLowerCase();
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      errors.email = 'Ingresa un email válido';
+      errors.email = t('auth.email') + ' ' + t('errors.notFound').toLowerCase();
     }
 
     // Password validation
     if (!formData.password) {
-      errors.password = 'La contraseña es requerida';
+      errors.password = t('auth.password') + ' ' + t('common.required').toLowerCase();
     }
 
     setValidationErrors(errors);
@@ -87,8 +89,8 @@ export function LoginPage() {
         <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-xl border border-white/50 p-8">
           {/* Header */}
           <div className="text-center mb-8">
-            <h1 className="text-3xl font-display text-[var(--color-accent)] mb-2">EventHub</h1>
-            <p className="text-gray-500 dark:text-gray-400">Iniciar Sesión</p>
+            <h1 className="text-3xl font-display text-[var(--color-accent)] mb-2">{t('common.appName')}</h1>
+            <p className="text-gray-500 dark:text-gray-400">{t('auth.login')}</p>
           </div>
 
           {/* Error Alert */}
@@ -108,7 +110,7 @@ export function LoginPage() {
             {/* Email Field */}
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                Email
+                {t('auth.email')}
               </label>
               <input
                 id="email"
@@ -132,7 +134,7 @@ export function LoginPage() {
             {/* Password Field */}
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
-                Contraseña
+                {t('auth.password')}
               </label>
               <div className="relative">
                 <input
@@ -173,7 +175,7 @@ export function LoginPage() {
                 className="w-4 h-4 text-[var(--color-primary)] border-[var(--color-secondary)] rounded focus:ring-[var(--color-accent)]"
               />
               <label htmlFor="rememberMe" className="ml-2 text-sm text-gray-600">
-                Recordarme
+                {t('common.rememberMe') || 'Recordarme'}
               </label>
             </div>
 
@@ -188,7 +190,7 @@ export function LoginPage() {
               ) : (
                 <span className="flex items-center justify-center gap-2">
                   <LogIn className="w-5 h-5" />
-                  Ingresar
+                  {t('auth.login')}
                 </span>
               )}
             </Button>
@@ -197,14 +199,14 @@ export function LoginPage() {
           {/* Links */}
           <div className="mt-6 text-center space-y-2">
             <p className="text-sm text-gray-600">
-              ¿No tienes cuenta?{' '}
+              {t('auth.noAccount')}{' '}
               <Link to="/register" className="text-[var(--color-primary)] hover:text-[var(--color-accent)] font-medium">
-                Regístrate
+                {t('auth.register')}
               </Link>
             </p>
             <p className="text-sm text-gray-500">
               <a href="#" className="hover:text-[var(--color-primary)] transition-colors">
-                ¿Olvidaste tu contraseña?
+                {t('auth.forgotPassword')}
               </a>
             </p>
           </div>

--- a/frontend/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend/src/features/auth/pages/RegisterPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import { UserPlus, AlertCircle, CheckCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { Button } from '@/shared/components/Button';
@@ -9,6 +10,7 @@ import { LoadingSpinner } from '@/shared/components/LoadingSpinner';
 type PasswordStrength = 'weak' | 'medium' | 'strong';
 
 export function RegisterPage() {
+  const { t } = useTranslation();
   const { register, isLoading, error, clearError, isAuthenticated } = useAuthStore();
   const navigate = useNavigate();
 
@@ -65,26 +67,26 @@ export function RegisterPage() {
 
     // Name validation
     if (!formData.name.trim()) {
-      errors.name = 'El nombre es requerido';
+      errors.name = t('auth.name') + ' ' + t('common.required').toLowerCase();
     }
 
     // Email validation
     if (!formData.email.trim()) {
-      errors.email = 'El email es requerido';
+      errors.email = t('auth.email') + ' ' + t('common.required').toLowerCase();
     } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      errors.email = 'Ingresa un email válido';
+      errors.email = t('auth.email') + ' ' + t('errors.notFound').toLowerCase();
     }
 
     // Password validation
     if (!formData.password) {
-      errors.password = 'La contraseña es requerida';
+      errors.password = t('auth.password') + ' ' + t('common.required').toLowerCase();
     } else if (formData.password.length < 6) {
-      errors.password = 'La contraseña debe tener al menos 6 caracteres';
+      errors.password = t('auth.password') + ' ' + t('auth.minLength').toLowerCase();
     }
 
     // Confirm password validation
     if (formData.password !== formData.confirmPassword) {
-      errors.confirmPassword = 'Las contraseñas no coinciden';
+      errors.confirmPassword = t('auth.passwordsMismatch');
     }
 
     setValidationErrors(errors);
@@ -123,11 +125,11 @@ export function RegisterPage() {
   const getStrengthLabel = (strength: PasswordStrength): string => {
     switch (strength) {
       case 'weak':
-        return 'Débil';
+        return t('auth.weak');
       case 'medium':
-        return 'Media';
+        return t('auth.medium');
       case 'strong':
-        return 'Fuerte';
+        return t('auth.strong');
     }
   };
 
@@ -141,8 +143,8 @@ export function RegisterPage() {
         <div className="bg-white/80 backdrop-blur-sm rounded-3xl shadow-xl border border-white/50 p-8">
           {/* Header */}
           <div className="text-center mb-8">
-            <h1 className="text-3xl font-display text-[var(--color-accent)] mb-2">EventHub</h1>
-            <p className="text-gray-500 dark:text-gray-400">Crear Cuenta</p>
+            <h1 className="text-3xl font-display text-[var(--color-accent)] mb-2">{t('common.appName')}</h1>
+            <p className="text-gray-500 dark:text-gray-400">{t('auth.register')}</p>
           </div>
 
           {/* Error Alert */}
@@ -162,7 +164,7 @@ export function RegisterPage() {
             {/* Name Field */}
             <div>
               <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-2">
-                Nombre Completo
+                {t('auth.name')}
               </label>
               <input
                 id="name"
@@ -186,7 +188,7 @@ export function RegisterPage() {
             {/* Email Field */}
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-                Email
+                {t('auth.email')}
               </label>
               <input
                 id="email"
@@ -210,7 +212,7 @@ export function RegisterPage() {
             {/* Password Field */}
             <div>
               <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
-                Contraseña
+                {t('auth.password')}
               </label>
               <input
                 id="password"
@@ -275,7 +277,7 @@ export function RegisterPage() {
             {/* Confirm Password Field */}
             <div>
               <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-2">
-                Confirmar Contraseña
+                {t('auth.confirmPassword')}
               </label>
               <input
                 id="confirmPassword"
@@ -307,7 +309,7 @@ export function RegisterPage() {
               ) : (
                 <span className="flex items-center justify-center gap-2">
                   <UserPlus className="w-5 h-5" />
-                  Crear Cuenta
+                  {t('auth.register')}
                 </span>
               )}
             </Button>
@@ -316,9 +318,9 @@ export function RegisterPage() {
           {/* Link to Login */}
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-600">
-              ¿Ya tienes cuenta?{' '}
+              {t('auth.hasAccount')}{' '}
               <Link to="/login" className="text-[var(--color-primary)] hover:text-[var(--color-accent)] font-medium">
-                Inicia sesión
+                {t('auth.login')}
               </Link>
             </p>
           </div>

--- a/frontend/src/features/dashboard/components/EmptyState.tsx
+++ b/frontend/src/features/dashboard/components/EmptyState.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import { PartyPopper } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/shared/components/Button';
@@ -10,6 +11,7 @@ interface EmptyStateProps {
 }
 
 export function EmptyState({ onCreateEvent }: EmptyStateProps) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const handleCreate = () => {
@@ -63,19 +65,19 @@ export function EmptyState({ onCreateEvent }: EmptyStateProps) {
         className="text-2xl font-display mb-3"
         style={{ color: 'var(--color-on-background)' }}
       >
-        No tenés eventos aún
+        {t('dashboard.empty.title')}
       </h2>
       <p 
         className="mb-8 max-w-sm mx-auto leading-relaxed"
         style={{ color: 'var(--color-on-surface-muted)' }}
       >
-        Crea tu primer evento y comienza a organizar experiencias únicas para tus invitados.
+        {t('dashboard.empty.subtitle')}
       </p>
 
       {/* CTA */}
       <Button onClick={handleCreate}>
         <PartyPopper className="w-5 h-5" />
-        Creá tu primer evento
+        {t('dashboard.empty.cta')}
       </Button>
 
       {/* Tips */}
@@ -84,7 +86,7 @@ export function EmptyState({ onCreateEvent }: EmptyStateProps) {
           className="text-sm font-medium mb-3"
           style={{ color: 'var(--color-on-surface)' }}
         >
-          ¿Qué podés crear?
+          {t('dashboard.empty.tipsTitle')}
         </h3>
         <ul 
           className="space-y-2 text-sm"
@@ -92,19 +94,19 @@ export function EmptyState({ onCreateEvent }: EmptyStateProps) {
         >
           <li className="flex items-center gap-2">
             <span style={{ color: 'var(--color-primary)' }}>✓</span>
-            Cumpleaños con quiz interactivo
+            {t('dashboard.empty.tip1')}
           </li>
           <li className="flex items-center gap-2">
             <span style={{ color: 'var(--color-primary)' }}>✓</span>
-            Eventos corporativos con carteleras
+            {t('dashboard.empty.tip2')}
           </li>
           <li className="flex items-center gap-2">
             <span style={{ color: 'var(--color-primary)' }}>✓</span>
-            Bodas con caja de sorpresas
+            {t('dashboard.empty.tip3')}
           </li>
           <li className="flex items-center gap-2">
             <span style={{ color: 'var(--color-primary)' }}>✓</span>
-            Cualquier celebración especial
+            {t('dashboard.empty.tip4')}
           </li>
         </ul>
       </div>

--- a/frontend/src/features/dashboard/pages/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,12 +1,14 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import { Plus, LogOut, RefreshCw, AlertCircle } from 'lucide-react';
 import { useAuthStore } from '@/features/auth/store/authStore';
 import { useDashboardStore } from '../store/dashboardStore';
 import { EventCard, EmptyState, DashboardSkeleton } from '../components';
 
 export function DashboardPage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { user, logout } = useAuthStore();
   const { events, isLoading, error, fetchEvents, deleteEvent, clearError } = useDashboardStore();
@@ -70,10 +72,10 @@ export function DashboardPage() {
         {/* Page Title */}
         <div className="mb-8">
           <h1 className="text-3xl font-display text-gray-800 dark:text-white mb-2">
-            Mis Eventos
+            {t('dashboard.title')}
           </h1>
           <p className="text-gray-500 dark:text-gray-400">
-            {events.length} {events.length === 1 ? 'evento' : 'eventos'} creados
+            {events.length} {events.length === 1 ? t('dashboard.eventsCount', { count: 1 }) : t('dashboard.eventsCount_plural', { count: events.length })}
           </p>
         </div>
 
@@ -92,7 +94,7 @@ export function DashboardPage() {
                 onClick={handleRefresh}
                 className="text-sm font-medium text-red-600 dark:text-red-400 hover:text-red-700 dark:hover:text-red-300 underline"
               >
-                Reintentar
+                {t('dashboard.error.retry')}
               </button>
             </motion.div>
           )}

--- a/frontend/src/features/landing/components/EventCodeForm.tsx
+++ b/frontend/src/features/landing/components/EventCodeForm.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Search, AlertCircle, CheckCircle } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { api } from '@/shared/lib/api';
 import { useLandingStore } from '../store/landingStore';
 import { useAuthStore } from '@/features/auth/store/authStore';
 
 export function EventCodeForm() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthStore();
   const { eventCode, setEventCode, isValidatingCode, codeError, setCodeValidation, trackCTA } = useLandingStore();
@@ -26,7 +28,7 @@ export function EventCodeForm() {
     
     const code = eventCode.trim().toLowerCase();
     if (!code) {
-      setCodeValidation(false, 'Ingresá un código de evento');
+      setCodeValidation(false, t('landing.joinSection.errorNoCode'));
       return;
     }
 
@@ -52,9 +54,9 @@ export function EventCodeForm() {
                         error?.message?.includes('No existe');
       
       if (isNotFound) {
-        setCodeValidation(false, 'Evento no encontrado. Verificá el código e intentá de nuevo.');
+        setCodeValidation(false, t('landing.joinSection.errorNotFound'));
       } else {
-        setCodeValidation(false, 'Error de conexión. Intentá de nuevo.');
+        setCodeValidation(false, t('landing.joinSection.errorConnection'));
       }
     }
   };
@@ -84,16 +86,16 @@ export function EventCodeForm() {
             className="inline-block px-4 py-1 text-sm font-medium rounded-full mb-4"
             style={{ background: 'var(--surface-container)', color: 'var(--primary)' }}
           >
-            Únete a la celebración
+            {t('landing.joinSection.title')}
           </motion.span>
           <h2 
             className="text-2xl md:text-3xl mb-3"
             style={{ fontFamily: 'var(--font-serif)', color: 'var(--on-background)' }}
           >
-            ¿Ya tenés un código de evento?
+            {t('landing.joinSection.subtitle')}
           </h2>
           <p style={{ color: 'var(--on-surface-variant)' }}>
-            Ingresá el código que recibiste para unirte a la celebración
+            {t('landing.joinSection.description')}
           </p>
         </motion.div>
 
@@ -116,7 +118,7 @@ export function EventCodeForm() {
               type="text"
               value={eventCode}
               onChange={handleChange}
-              placeholder="Ej: cumple-ana-2026"
+              placeholder={t('landing.joinSection.placeholder')}
               disabled={isValidatingCode || isSuccess}
               className={`
                 w-full pl-12 pr-32 py-4 text-lg rounded-full
@@ -153,17 +155,17 @@ export function EventCodeForm() {
                 {isValidatingCode ? (
                   <span className="flex items-center gap-2">
                     <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                    Buscando...
+                    {t('landing.joinSection.searching')}
                   </span>
                 ) : isSuccess ? (
                   <span className="flex items-center gap-2">
                     <CheckCircle className="w-4 h-4" />
-                    ¡Encontrado!
+                    {t('landing.joinSection.found')}
                   </span>
                 ) : (
                   <span className="flex items-center gap-2">
                     <Search className="w-4 h-4" />
-                    Buscar
+                    {t('landing.joinSection.search')}
                   </span>
                 )}
               </button>
@@ -186,7 +188,7 @@ export function EventCodeForm() {
           {/* Help text */}
           {!codeError && !isSuccess && (
             <p className="mt-3 text-xs text-center" style={{ color: 'var(--on-surface-variant)' }}>
-              El código es la última parte de la URL del evento
+              {t('landing.joinSection.helpText')}
             </p>
           )}
         </motion.form>
@@ -200,14 +202,14 @@ export function EventCodeForm() {
           className="mt-8 text-center"
         >
           <p className="text-sm mb-2" style={{ color: 'var(--on-surface-variant)' }}>
-            ¿No tenés un código?
+            {t('landing.joinSection.noCode')}
           </p>
           <button
             onClick={handleCreateEvent}
             className="font-medium text-sm underline underline-offset-4 transition-colors"
             style={{ color: 'var(--primary)' }}
           >
-            Creá tu propio evento
+            {t('landing.joinSection.createOwnEvent')}
           </button>
         </motion.div>
       </div>

--- a/frontend/src/features/landing/components/FeaturesGrid.tsx
+++ b/frontend/src/features/landing/components/FeaturesGrid.tsx
@@ -1,24 +1,25 @@
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 import type { LandingFeature } from '../types/landing.types';
 
 const features: LandingFeature[] = [
   {
     id: 'quiz',
     icon: '🧠',
-    title: 'Quiz Interactivo',
-    description: 'Preguntas personalizadas para conocer a tu cumpleañero/a. Ranking en tiempo real.',
+    titleKey: 'landing.features.quiz.title',
+    descriptionKey: 'landing.features.quiz.description',
   },
   {
     id: 'corkboard',
     icon: '📌',
-    title: 'Cartelera de Fotos',
-    description: 'Invitados comparten fotos y mensajes en un corcho digital colaborativo.',
+    titleKey: 'landing.features.corkboard.title',
+    descriptionKey: 'landing.features.corkboard.description',
   },
   {
     id: 'secret',
     icon: '🎁',
-    title: 'Caja Secreta',
-    description: 'Sorpresas de invitados remotos que se revelan en el momento perfecto.',
+    titleKey: 'landing.features.secret.title',
+    descriptionKey: 'landing.features.secret.description',
   },
 ];
 
@@ -53,6 +54,8 @@ const iconVariants = {
 };
 
 export function FeaturesGrid() {
+  const { t } = useTranslation();
+
   return (
     <section className="py-20 px-4 bg-white dark:bg-slate-900">
       <div className="max-w-5xl mx-auto">
@@ -72,13 +75,13 @@ export function FeaturesGrid() {
             className="inline-block px-4 py-1 text-sm font-medium rounded-full mb-4"
             style={{ background: 'color-mix(in srgb, var(--color-primary) 15%, transparent)', color: 'var(--color-primary)' }}
           >
-            Características
+            {t('landing.features.characteristics')}
           </motion.span>
           <h2 className="text-3xl md:text-4xl font-display text-gray-800 dark:text-white mb-4">
-            Todo lo que necesitás para tu evento
+            {t('landing.features.title')}
           </h2>
           <p className="text-gray-500 dark:text-gray-400 max-w-2xl mx-auto">
-            Herramientas interactivas diseñadas para hacer tu celebración única y memorable.
+            {t('landing.features.subtitle')}
           </p>
         </motion.div>
 
@@ -117,12 +120,12 @@ export function FeaturesGrid() {
               
               {/* Title */}
               <h3 className="text-xl font-semibold text-gray-800 dark:text-white mb-2">
-                {feature.title}
+                {t(feature.titleKey)}
               </h3>
               
               {/* Description */}
               <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
-                {feature.description}
+                {t(feature.descriptionKey)}
               </p>
 
               {/* Feature indicator */}
@@ -135,7 +138,7 @@ export function FeaturesGrid() {
                 transition={{ delay: 0.3 + index * 0.1 }}
               >
                 <span className="text-xs font-medium" style={{ color: 'var(--color-primary)' }}>
-                  ✓ Incluido en todos los planes
+                  {t('landing.features.includedAllPlans')}
                 </span>
               </motion.div>
             </motion.div>

--- a/frontend/src/features/landing/components/HeroSection.tsx
+++ b/frontend/src/features/landing/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Sparkles, PartyPopper, ArrowRight } from 'lucide-react';
 import { Button } from '@/shared/components/Button';
 import { useLandingStore } from '../store/landingStore';
@@ -26,6 +27,7 @@ const itemVariants = {
 };
 
 export function HeroSection() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { trackCTA } = useLandingStore();
   const { isAuthenticated } = useAuthStore();
@@ -92,7 +94,7 @@ export function HeroSection() {
               className="text-xs md:text-sm font-medium"
               style={{ color: 'var(--color-on-surface)' }}
             >
-              Plataforma de eventos interactivos
+              {t('landing.hero.tagline')}
             </span>
           </div>
         </motion.div>
@@ -119,7 +121,7 @@ export function HeroSection() {
           className="text-lg md:text-2xl mb-2 md:mb-4 font-serif"
           style={{ color: 'var(--color-on-background)' }}
         >
-          Creá experiencias memorables
+          {t('landing.hero.title')}
         </motion.p>
 
         {/* Subtitle */}
@@ -128,8 +130,7 @@ export function HeroSection() {
           className="text-sm md:text-base mb-8 md:mb-10 max-w-2xl mx-auto px-4"
           style={{ color: 'var(--color-on-surface-muted)' }}
         >
-          Organizá eventos únicos con quizzes interactivos, carteleras de fotos y 
-          cajas secretas. Todo en un solo lugar, fácil de compartir.
+          {t('landing.hero.subtitle')}
         </motion.p>
 
         {/* CTA Buttons */}
@@ -139,12 +140,12 @@ export function HeroSection() {
         >
           <Button onClick={handleCreateEvent}>
             <PartyPopper className="w-4 h-4 md:w-5 md:h-5" />
-            Crear Evento
+            {t('landing.hero.createEvent')}
           </Button>
 
           <Button onClick={handleJoinEvent} variant="outline">
             <ArrowRight className="w-4 h-4 md:w-5 md:h-5" />
-            Ingresar a Evento
+            {t('landing.hero.joinEvent')}
           </Button>
         </motion.div>
 
@@ -164,7 +165,7 @@ export function HeroSection() {
               className="text-xs md:text-sm"
               style={{ color: 'var(--color-on-surface-muted)' }}
             >
-              Eventos creados
+              {t('landing.hero.stats.eventsCreated')}
             </p>
           </div>
           <div 
@@ -182,7 +183,7 @@ export function HeroSection() {
               className="text-xs md:text-sm"
               style={{ color: 'var(--color-on-surface-muted)' }}
             >
-              Invitados por evento
+              {t('landing.hero.stats.guestsPerEvent')}
             </p>
           </div>
           <div 
@@ -200,7 +201,7 @@ export function HeroSection() {
               className="text-xs md:text-sm"
               style={{ color: 'var(--color-on-surface-muted)' }}
             >
-              Satisfacción
+              {t('landing.hero.stats.satisfaction')}
             </p>
           </div>
         </motion.div>

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -1,9 +1,11 @@
 import { motion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
 
 /**
  * LandingFooter - About, Contact, Privacy, Terms, social links.
  */
 export function LandingFooter() {
+  const { t } = useTranslation();
   const currentYear = new Date().getFullYear();
 
   return (
@@ -28,8 +30,7 @@ export function LandingFooter() {
               </span>
             </div>
             <p className="text-sm mb-4" style={{ color: 'var(--on-surface-variant)' }}>
-              Creá experiencias memorables para tus celebraciones.
-              Eventos interactivos con quizzes, carteleras de fotos y cajas secretas.
+              {t('landing.footer.description')}
             </p>
             {/* Social links */}
             <div className="flex gap-3">
@@ -63,14 +64,14 @@ export function LandingFooter() {
               className="font-semibold mb-3 text-sm"
               style={{ color: 'var(--on-surface)' }}
             >
-              Producto
+              {t('landing.footer.product')}
             </h4>
             <ul className="space-y-2">
               {[
-                { label: 'Funciones', href: '#features' },
-                { label: 'Precios', href: '#pricing' },
-                { label: 'Demo', href: '#demo' },
-                { label: 'FAQ', href: '#faq' },
+                { label: t('landing.footer.functions'), href: '#features' },
+                { label: t('landing.pricing.prices'), href: '#pricing' },
+                { label: t('landing.footer.demo'), href: '#demo' },
+                { label: t('landing.footer.faq'), href: '#faq' },
               ].map((link) => (
                 <li key={link.label}>
                   <a
@@ -91,14 +92,14 @@ export function LandingFooter() {
               className="font-semibold mb-3 text-sm"
               style={{ color: 'var(--on-surface)' }}
             >
-              Legal
+              {t('landing.footer.legal')}
             </h4>
             <ul className="space-y-2">
               {[
-                { label: 'Política de Privacidad', href: '/privacy' },
-                { label: 'Términos de Servicio', href: '/terms' },
-                { label: 'Contacto', href: '/contact' },
-                { label: 'Sobre nosotros', href: '/about' },
+                { label: t('landing.footer.privacy'), href: '/privacy' },
+                { label: t('landing.footer.terms'), href: '/terms' },
+                { label: t('landing.footer.contact'), href: '/contact' },
+                { label: t('landing.footer.about'), href: '/about' },
               ].map((link) => (
                 <li key={link.label}>
                   <a
@@ -120,10 +121,10 @@ export function LandingFooter() {
           style={{ borderColor: 'var(--surface-container)' }}
         >
           <p className="text-xs" style={{ color: 'var(--on-surface-variant)' }}>
-            © {currentYear} EventHub. Todos los derechos reservados.
+            © {currentYear} EventHub. {t('landing.footer.rights')}
           </p>
           <p className="text-xs" style={{ color: 'var(--on-surface-variant)' }}>
-            Hecho con ❤️ para celebraciones memorables
+            {t('landing.footer.madeWith')}
           </p>
         </div>
       </div>

--- a/frontend/src/features/landing/components/PricingTable.tsx
+++ b/frontend/src/features/landing/components/PricingTable.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 interface PricingFeature {
   text: string;
@@ -61,6 +62,7 @@ const tiers: PricingTier[] = [
  * Price point: $4.99 USD (user-specified).
  */
 export function PricingTable() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const handleCTA = (tier: PricingTier) => {
@@ -90,169 +92,191 @@ export function PricingTable() {
             className="inline-block px-4 py-1 text-sm font-medium rounded-full mb-4"
             style={{ background: 'color-mix(in srgb, var(--color-primary) 15%, transparent)', color: 'var(--color-primary)' }}
           >
-            Precios
+            {t('landing.pricing.prices')}
           </span>
           <h2 className="text-2xl md:text-3xl mb-3" style={{ fontFamily: 'var(--font-serif)' }}>
-            Simple y transparente
+            {t('landing.pricing.title')}
           </h2>
           <p style={{ color: 'var(--on-surface-variant)' }}>
-            Empezá gratis, actualizá cuando quieras
+            {t('landing.pricing.subtitle')}
           </p>
         </motion.div>
 
         {/* Pricing Cards */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {tiers.map((tier, index) => (
-            <motion.div
-              key={tier.name}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, delay: index * 0.1 }}
-              className={`relative rounded-2xl p-6 ${tier.popular ? '' : 'shadow-md'}`}
-              style={
-                tier.popular
-                  ? {
-                      background: 'linear-gradient(135deg, var(--primary) 0%, #BE185D 100%)',
-                      color: 'white',
-                      boxShadow: '0 20px 25px -5px color-mix(in srgb, var(--color-primary) 30%, transparent), 0 8px 10px -6px color-mix(in srgb, var(--color-primary) 30%, transparent)',
-                    }
-                  : {
-                      background: 'var(--surface-container)',
-                      border: '1px solid var(--surface-container-high)',
-                    }
-              }
-            >
-              {/* Popular badge */}
-              {tier.popular && (
-                <div className="absolute -top-3 left-1/2 -translate-x-1/2">
-                  <span
-                    className="text-xs font-bold px-3 py-1 rounded-full shadow"
-                    style={{ background: 'white', color: 'var(--color-primary)' }}
-                  >
-                    ⭐ Más popular
-                  </span>
-                </div>
-              )}
+          {['free', 'premium'].map((tierKey, index) => {
+            const tier = {
+              name: t(`landing.pricing.${tierKey}.name`),
+              description: t(`landing.pricing.${tierKey}.description`),
+              price: tierKey === 'premium' ? t(`landing.pricing.${tierKey}.price`) : undefined,
+              popular: tierKey === 'premium',
+              cta: t(`landing.pricing.${tierKey}.cta`),
+            };
+            const tierFeatures = [
+              { key: tierKey === 'free' ? 'upTo20Guests' : 'unlimitedGuests', included: true },
+              { key: tierKey === 'free' ? '1ActiveEvent' : 'unlimitedEvents', included: true },
+              { key: tierKey === 'free' ? 'basicQuiz' : 'fullQuiz', included: true },
+              { key: tierKey === 'free' ? 'photoBoard' : 'photoBoardVideos', included: true },
+              { key: 'liveRanking', included: true },
+              { key: tierKey === 'free' ? 'basicAnalytics' : 'advancedAnalytics', included: true },
+              { key: 'secretBox', included: tierKey === 'premium' },
+              { key: 'videoPostcards', included: tierKey === 'premium' },
+              { key: 'prioritySupport', included: tierKey === 'premium' },
+              { key: 'unlimitedEvents', included: tierKey === 'premium' ? undefined : false },
+            ].filter(f => f.included !== undefined) as { key: string; included: boolean }[];
 
-              {/* Tier name */}
-              <h3
-                className="text-xl font-semibold mb-1"
-                style={{
-                  fontFamily: 'var(--font-serif)',
-                  ...(tier.popular ? { color: 'white' } : {}),
-                }}
+            return (
+              <motion.div
+                key={tierKey}
+                initial={{ opacity: 0, y: 30 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.5, delay: index * 0.1 }}
+                className={`relative rounded-2xl p-6 ${tier.popular ? '' : 'shadow-md'}`}
+                style={
+                  tier.popular
+                    ? {
+                        background: 'linear-gradient(135deg, var(--primary) 0%, #BE185D 100%)',
+                        color: 'white',
+                        boxShadow: '0 20px 25px -5px color-mix(in srgb, var(--color-primary) 30%, transparent), 0 8px 10px -6px color-mix(in srgb, var(--color-primary) 30%, transparent)',
+                      }
+                    : {
+                        background: 'var(--surface-container)',
+                        border: '1px solid var(--surface-container-high)',
+                      }
+                }
               >
-                {tier.name}
-              </h3>
-
-              {/* Price */}
-              <div className="mb-4">
-                {tier.price ? (
-                  <div className="flex items-baseline gap-1">
+                {/* Popular badge */}
+                {tier.popular && (
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2">
                     <span
-                      className="text-4xl font-bold"
-                      style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
+                      className="text-xs font-bold px-3 py-1 rounded-full shadow"
+                      style={{ background: 'white', color: 'var(--color-primary)' }}
                     >
-                      {tier.price}
-                    </span>
-                    <span
-                      className="text-sm"
-                      style={
-                        tier.popular
-                          ? { color: 'rgba(255,255,255,0.7)' }
-                          : { color: 'var(--on-surface-variant)' }
-                      }
-                    >
-                      USD
-                    </span>
-                  </div>
-                ) : (
-                  <div
-                    className="text-3xl font-bold"
-                    style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
-                  >
-                    $0
-                    <span
-                      className="text-sm font-normal ml-1"
-                      style={
-                        tier.popular
-                          ? { color: 'rgba(255,255,255,0.7)' }
-                          : { color: 'var(--on-surface-variant)' }
-                      }
-                    >
-                      gratis para siempre
+                      {t('landing.pricing.mostPopular')}
                     </span>
                   </div>
                 )}
-              </div>
 
-              {/* Description */}
-              <p
-                className="text-sm mb-6"
-                style={
-                  tier.popular
-                    ? { color: 'rgba(255,255,255,0.8)' }
-                    : { color: 'var(--on-surface-variant)' }
-                }
-              >
-                {tier.description}
-              </p>
+                {/* Tier name */}
+                <h3
+                  className="text-xl font-semibold mb-1"
+                  style={{
+                    fontFamily: 'var(--font-serif)',
+                    ...(tier.popular ? { color: 'white' } : {}),
+                  }}
+                >
+                  {tier.name}
+                </h3>
 
-              {/* Features */}
-              <ul className="space-y-2 mb-6">
-                {tier.features.map((feature, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm">
-                    <span className="flex-shrink-0 mt-0.5">
-                      {feature.included ? (
-                        <span
-                          className="text-lg"
-                          style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
-                        >
-                          ✓
-                        </span>
-                      ) : (
-                        <span
-                          className="text-lg"
-                          style={{ color: 'var(--on-surface-variant)', opacity: 0.4 }}
-                        >
-                          ✕
-                        </span>
-                      )}
-                    </span>
-                    <span
-                      style={
-                        feature.included
-                          ? tier.popular
-                            ? { color: 'white' }
-                            : { color: 'var(--on-surface)' }
-                          : { color: 'var(--on-surface-variant)', opacity: 0.5 }
-                      }
+                {/* Price */}
+                <div className="mb-4">
+                  {tier.price ? (
+                    <div className="flex items-baseline gap-1">
+                      <span
+                        className="text-4xl font-bold"
+                        style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
+                      >
+                        {tier.price}
+                      </span>
+                      <span
+                        className="text-sm"
+                        style={
+                          tier.popular
+                            ? { color: 'rgba(255,255,255,0.7)' }
+                            : { color: 'var(--on-surface-variant)' }
+                        }
+                      >
+                        USD
+                      </span>
+                    </div>
+                  ) : (
+                    <div
+                      className="text-3xl font-bold"
+                      style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
                     >
-                      {feature.text}
-                    </span>
-                  </li>
-                ))}
-              </ul>
+                      {t('landing.pricing.free.price')}
+                      <span
+                        className="text-sm font-normal ml-1"
+                        style={
+                          tier.popular
+                            ? { color: 'rgba(255,255,255,0.7)' }
+                            : { color: 'var(--on-surface-variant)' }
+                        }
+                      >
+                        {t('landing.pricing.free.priceSuffix')}
+                      </span>
+                    </div>
+                  )}
+                </div>
 
-              {/* CTA Button */}
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                onClick={() => handleCTA(tier)}
-                className={`w-full py-3 rounded-full font-semibold transition-colors ${
-                  tier.popular ? '' : 'border-2 hover:opacity-80'
-                }`}
-                style={
-                  tier.popular
-                    ? { background: 'white', color: 'var(--color-primary)' }
-                    : { borderColor: 'var(--primary)', color: 'var(--primary)' }
-                }
-              >
-                {tier.cta}
-              </motion.button>
-            </motion.div>
-          ))}
+                {/* Description */}
+                <p
+                  className="text-sm mb-6"
+                  style={
+                    tier.popular
+                      ? { color: 'rgba(255,255,255,0.8)' }
+                      : { color: 'var(--on-surface-variant)' }
+                  }
+                >
+                  {tier.description}
+                </p>
+
+                {/* Features */}
+                <ul className="space-y-2 mb-6">
+                  {tierFeatures.map((feature, i) => (
+                    <li key={i} className="flex items-start gap-2 text-sm">
+                      <span className="flex-shrink-0 mt-0.5">
+                        {feature.included ? (
+                          <span
+                            className="text-lg"
+                            style={tier.popular ? { color: 'white' } : { color: 'var(--primary)' }}
+                          >
+                            ✓
+                          </span>
+                        ) : (
+                          <span
+                            className="text-lg"
+                            style={{ color: 'var(--on-surface-variant)', opacity: 0.4 }}
+                          >
+                            ✕
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        style={
+                          feature.included
+                            ? tier.popular
+                              ? { color: 'white' }
+                              : { color: 'var(--on-surface)' }
+                            : { color: 'var(--on-surface-variant)', opacity: 0.5 }
+                        }
+                      >
+                        {t(`landing.pricing.${tierKey}.features.${feature.key}`)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+
+                {/* CTA Button */}
+                <motion.button
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  onClick={() => handleCTA({ name: tier.name } as any)}
+                  className={`w-full py-3 rounded-full font-semibold transition-colors ${
+                    tier.popular ? '' : 'border-2 hover:opacity-80'
+                  }`}
+                  style={
+                    tier.popular
+                      ? { background: 'white', color: 'var(--color-primary)' }
+                      : { borderColor: 'var(--primary)', color: 'var(--primary)' }
+                  }
+                >
+                  {tier.cta}
+                </motion.button>
+              </motion.div>
+            );
+          })}
         </div>
 
         {/* Trust signals */}
@@ -264,7 +288,7 @@ export function PricingTable() {
           className="text-center text-xs mt-6"
           style={{ color: 'var(--on-surface-variant)' }}
         >
-          Sin tarjeta de crédito requerida · Cancela cuando quieras
+          {t('landing.pricing.trustSignals')}
         </motion.p>
       </div>
     </section>

--- a/frontend/src/features/landing/pages/LandingPage.tsx
+++ b/frontend/src/features/landing/pages/LandingPage.tsx
@@ -1,7 +1,9 @@
 import { motion } from 'framer-motion';
 import { useNavigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { useLandingStore } from '../store/landingStore';
 import { useAuthStore } from '@/features/auth/store/authStore';
+import { LanguageSwitcher } from '@/shared/components/LanguageSwitcher';
 import { EventCodeForm } from '../components/EventCodeForm';
 import { DemoVideoSection } from '../components/DemoVideoSection';
 import { PricingTable } from '../components/PricingTable';
@@ -9,6 +11,7 @@ import { TestimonialsCarousel } from '../components/TestimonialsCarousel';
 import { LandingFooter } from '../components/LandingFooter';
 
 export function LandingPage() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthStore();
   const { trackCTA } = useLandingStore();
@@ -38,29 +41,30 @@ export function LandingPage() {
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-2 flex-shrink-0">
             <span className="text-xl font-bold" style={{ fontFamily: 'var(--font-serif)', color: 'var(--primary)' }}>
-              EventHub
+              {t('common.appName')}
             </span>
           </div>
           <nav className="flex items-center gap-3 flex-nowrap">
+            <LanguageSwitcher />
             {isAuthenticated ? (
               <button
                 onClick={() => navigate('/dashboard')}
                 className="text-sm font-medium transition-colors whitespace-nowrap"
                 style={{ color: 'var(--on-surface-variant)' }}
               >
-                Dashboard
+                {t('nav.dashboard')}
               </button>
             ) : (
               <>
                 <Link to="/login" className="text-sm font-medium transition-colors whitespace-nowrap" style={{ color: 'var(--on-surface-variant)' }}>
-                  Ingresar
+                  {t('auth.login')}
                 </Link>
                 <Link
                   to="/register"
                   className="text-sm font-semibold px-3 py-1.5 rounded-full transition-colors whitespace-nowrap"
                   style={{ background: 'var(--primary)', color: 'white' }}
                 >
-                  Registrarse
+                  {t('auth.register')}
                 </Link>
               </>
             )}
@@ -81,7 +85,7 @@ export function LandingPage() {
             className="inline-block text-xs font-semibold tracking-widest uppercase"
             style={{ color: 'var(--primary)' }}
           >
-            The Digital Gala Experience
+            {t('landing.hero.tagline')}
           </span>
         </motion.div>
 
@@ -93,10 +97,7 @@ export function LandingPage() {
           className="text-4xl md:text-5xl lg:text-6xl text-center leading-tight mb-6"
           style={{ fontFamily: 'var(--font-serif)' }}
         >
-          Creá experiencias{' '}
-          <span className="italic" style={{ color: 'var(--primary)' }}>
-            memorables
-          </span>
+          {t('landing.hero.title')}
         </motion.h1>
 
         {/* Subtitle */}
@@ -107,8 +108,7 @@ export function LandingPage() {
           className="text-center text-base md:text-lg max-w-lg mx-auto mb-10"
           style={{ color: 'var(--on-surface-variant)' }}
         >
-          Eventos interactivos con quizzes personalizados, carteleras de fotos y cajas secretas. 
-          Todo lo que necesitás para celebrar.
+          {t('landing.hero.subtitle')}
         </motion.p>
 
         {/* CTA Buttons - Stacked */}
@@ -119,10 +119,10 @@ export function LandingPage() {
           className="flex flex-col items-center gap-3 max-w-sm mx-auto"
         >
           <button onClick={handleCreateEvent} className="stitch-btn-primary w-full">
-            Crear mi Evento
+            {t('landing.hero.createEvent')}
           </button>
           <button onClick={handleJoinEvent} className="stitch-btn-outline w-full">
-            Ingresar a Evento
+            {t('landing.hero.joinEvent')}
           </button>
         </motion.div>
 
@@ -187,10 +187,10 @@ export function LandingPage() {
             className="text-center mb-10"
           >
             <h2 className="text-2xl md:text-3xl mb-3" style={{ fontFamily: 'var(--font-serif)' }}>
-              Todo lo que necesitás
+              {t('landing.features.title')}
             </h2>
             <p style={{ color: 'var(--on-surface-variant)' }}>
-              Herramientas interactivas para hacer tu celebración única
+              {t('landing.features.subtitle')}
             </p>
           </motion.div>
 
@@ -206,30 +206,29 @@ export function LandingPage() {
             >
               <div className="text-4xl mb-4">🧠</div>
               <h3 className="text-xl font-semibold mb-2" style={{ fontFamily: 'var(--font-serif)' }}>
-                Quiz Interactivo
+                {t('landing.features.quiz.title')}
               </h3>
               <p style={{ color: 'var(--on-surface-variant)' }}>
-                Preguntas personalizadas para conocer al festejado. Ranking en tiempo real 
-                con medals 3D y animaciones.
+                {t('landing.features.quiz.description')}
               </p>
               <div className="mt-6 flex flex-wrap gap-2">
                 <span 
                   className="text-xs px-2 py-1 rounded-full"
                   style={{ background: 'var(--surface-container-high)' }}
                 >
-                  Multiple choice
+                  {t('quiz.questions.multipleChoice')}
                 </span>
                 <span 
                   className="text-xs px-2 py-1 rounded-full"
                   style={{ background: 'var(--surface-container-high)' }}
                 >
-                  This or That
+                  {t('quiz.questions.thisOrThat')}
                 </span>
                 <span 
                   className="text-xs px-2 py-1 rounded-full"
                   style={{ background: 'var(--surface-container-high)' }}
                 >
-                  Texto libre
+                  {t('quiz.questions.text')}
                 </span>
               </div>
             </motion.div>
@@ -245,10 +244,10 @@ export function LandingPage() {
             >
               <div className="text-4xl mb-4">📌</div>
               <h3 className="text-lg font-semibold mb-2" style={{ fontFamily: 'var(--font-serif)' }}>
-                Cartelera de Fotos
+                {t('landing.features.corkboard.title')}
               </h3>
               <p style={{ color: 'var(--on-surface-variant)' }}>
-                Invitados comparten fotos y mensajes en un corcho digital colaborativo.
+                {t('landing.features.corkboard.description')}
               </p>
             </motion.div>
 
@@ -263,10 +262,10 @@ export function LandingPage() {
             >
               <div className="text-4xl mb-4">🎁</div>
               <h3 className="text-lg font-semibold mb-2" style={{ fontFamily: 'var(--font-serif)' }}>
-                Caja Secreta
+                {t('landing.features.secret.title')}
               </h3>
               <p style={{ color: 'var(--on-surface-variant)' }}>
-                Sorpresas de invitados remotos que se revelan en el momento perfecto.
+                {t('landing.features.secret.description')}
               </p>
             </motion.div>
 
@@ -282,20 +281,20 @@ export function LandingPage() {
               <div className="flex items-center justify-between">
                 <div>
                   <h3 className="text-xl font-semibold mb-2" style={{ fontFamily: 'var(--font-serif)', color: 'white' }}>
-                    +500 eventos creados
+                    +500 {t('landing.hero.stats.eventsCreated')}
                   </h3>
                   <p className="text-sm opacity-90">
-                    Únete a cientos de celebraciones memorables
+                    {t('landing.features.subtitle')}
                   </p>
                 </div>
                 <div className="flex gap-4">
                   <div className="text-center">
                     <div className="text-3xl font-bold">4.9</div>
-                    <div className="text-xs opacity-80">★ Rating</div>
+                    <div className="text-xs opacity-80">★ {t('landing.hero.stats.satisfaction')}</div>
                   </div>
                   <div className="text-center">
                     <div className="text-3xl font-bold">50+</div>
-                    <div className="text-xs opacity-80">Invitados</div>
+                    <div className="text-xs opacity-80">{t('landing.hero.stats.guestsPerEvent')}</div>
                   </div>
                 </div>
               </div>
@@ -336,7 +335,7 @@ export function LandingPage() {
               home
             </span>
             <span className="text-xs font-medium" style={{ color: 'var(--primary)' }}>
-              Inicio
+              {t('nav.home')}
             </span>
           </button>
           
@@ -348,7 +347,7 @@ export function LandingPage() {
               add_circle
             </span>
             <span className="text-xs font-medium" style={{ color: 'var(--on-surface-variant)' }}>
-              Crear
+              {t('nav.create')}
             </span>
           </button>
           
@@ -357,7 +356,7 @@ export function LandingPage() {
               explore
             </span>
             <span className="text-xs font-medium" style={{ color: 'var(--on-surface-variant)' }}>
-              Explorar
+              {t('nav.explore')}
             </span>
           </button>
           
@@ -370,7 +369,7 @@ export function LandingPage() {
                 person
               </span>
               <span className="text-xs font-medium" style={{ color: 'var(--on-surface-variant)' }}>
-                Perfil
+                {t('nav.profile')}
               </span>
             </button>
           ) : (
@@ -382,7 +381,7 @@ export function LandingPage() {
                 person
               </span>
               <span className="text-xs font-medium" style={{ color: 'var(--on-surface-variant)' }}>
-                Perfil
+                {t('nav.profile')}
               </span>
             </button>
           )}

--- a/frontend/src/features/landing/types/landing.types.ts
+++ b/frontend/src/features/landing/types/landing.types.ts
@@ -2,8 +2,8 @@
 export interface LandingFeature {
   id: string;
   icon: string;
-  title: string;
-  description: string;
+  titleKey: string;
+  descriptionKey: string;
 }
 
 export interface CTAEvent {


### PR DESCRIPTION
Closes #61

The LanguageSwitcher component existed and worked, but no components actually consumed translations — all UI text was hardcoded in Spanish.

## Changes
- Added `useTranslation()` to all landing page components (Hero, Features, Pricing, Footer, EventCodeForm)
- Added `useTranslation()` to auth pages (Login, Register)
- Added `useTranslation()` to dashboard pages and components
- Integrated LanguageSwitcher into the Header so users can switch languages
- Added missing translation keys to both `es` and `en` translation files
- Updated `LandingFeature` type to use translation keys instead of hardcoded strings
- Added `landing.footer.description` key for the marketing copy paragraph

## Verified
- TypeScript compilation passes
- Translation files are valid JSON