### PR TITLE
chore(frontend): add .env.example with documented variables

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,46 @@
+# ============================================
+# EventHub Frontend — Environment Variables
+# ============================================
+# Copy this file to .env and adjust values as needed:
+#   cp .env.example .env
+#
+# Vite only exposes env vars prefixed with VITE_ to the client bundle.
+# All other vars are ignored at build time.
+#
+# ⚠️  IMPORTANT: These values are baked into the bundle at BUILD time.
+#    To change them in production, you MUST rebuild and redeploy.
+#
+#    docker-compose up --build -d frontend
+# ============================================
+
+# ============================================
+# API & WebSocket
+# ============================================
+
+# Backend API base URL
+# - Docker / Production:  /api  (Nginx proxies /api to the backend)
+# - Local dev (no Docker): http://localhost:8080/api
+VITE_API_URL=/api
+
+# WebSocket URL for real-time features (ranking, postcards)
+# - Docker / Production:  ws://localhost:8080/ws  (or wss:// in prod)
+# - Local dev:            ws://localhost:8080/ws
+VITE_WS_URL=ws://localhost:8080/ws
+
+# ============================================
+# FEATURE FLAGS
+# ============================================
+# Toggle features on/off at build time.
+# All values must be literal strings: "true" or "false"
+
+# Cartelera de Corcho — Photo/video board for guests
+# Enable ON the day of the event, then rebuild & redeploy
+VITE_ENABLE_CORKBOARD=false
+
+# Secret Box — Surprise postcards from guests who can't attend
+# Enable BEFORE the event so the secret link works
+VITE_ENABLE_SECRET_BOX=false
+
+# Google Drive Backup — Auto-backup postcards to Google Drive
+# Requires OAuth setup in GCP. See docs/google-drive-backup.md
+VITE_ENABLE_GOOGLE_DRIVE_BACKUP=false


### PR DESCRIPTION
Closes #57

## What
Created a dedicated `frontend/.env.example` with all Vite environment variables documented.

## Why
- Previously, frontend env vars were only in the root `.env.example` mixed with backend/infra vars
- The existing `frontend/.env` was incomplete (missing WS_URL, SECRET_BOX, GOOGLE_DRIVE flags)
- New frontend devs had no standalone reference for what the frontend needs

## What's Included
- `VITE_API_URL` — Backend API base URL (with Docker vs local dev guidance)
- `VITE_WS_URL` — WebSocket URL for real-time features
- Feature flags with inline docs:
  - `VITE_ENABLE_CORKBOARD`
  - `VITE_ENABLE_SECRET_BOX`
  - `VITE_ENABLE_GOOGLE_DRIVE_BACKUP"
- Security note explaining that Vite bakes env vars at BUILD time

## Not Included (intentionally)
- No backend/infra variables (DB, JWT, ports, etc. — those stay in root `.env.example`)
- No real credentials or secrets