### PR TITLE
fix(frontend): remove stale exports from postcards index

### DIFF
--- a/frontend/src/features/postcards/index.ts
+++ b/frontend/src/features/postcards/index.ts
@@ -2,10 +2,6 @@
 export { CorkboardPage } from './pages/CorkboardPage';
 export { SecretBoxPage } from './pages/SecretBoxPage';
 export { usePostcards } from './hooks/usePostcards';
-export { useDescriptions } from './hooks/useDescriptions';
 export { usePostcardStore } from './store/postcardStore';
 export { postcardService } from './services/postcardApi';
-export { StampLayer } from './components/StampLayer';
-export { StampItem } from './components/StampItem';
-export type { StampPosition } from './components/StampItem';
 export type { Postcard, CreatePostcardPayload, SecretBoxStatus } from './types/postcards.types';


### PR DESCRIPTION
Hotfix for v0.4.5

The previous PR removed StampLayer/StampItem/useDescriptions but forgot to clean up their re-exports from `features/postcards/index.ts`.

This broke production Docker builds with:
- `TS2307: Cannot find module './hooks/useDescriptions'`
- `TS2307: Cannot find module './components/StampLayer'`
- `TS2307: Cannot find module './components/StampItem'`

## Fix
Removed all four stale exports from the barrel file.

## Verified
- `tsc --noEmit` passes
- `docker-compose up --build` succeeds