### PR TITLE
feat(backend): add Resend email integration for password recovery

### DIFF
--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -90,8 +90,25 @@ func main() {
 		log.Fatal("JWT_SECRET environment variable is required")
 	}
 	authService := services.NewAuthService(userRepo, jwtSecret)
-	emailSender := services.NewConsoleEmailSender()
-	authServiceWithReset := services.NewAuthServiceWithReset(userRepo, resetTokenRepo, emailSender, jwtSecret)
+
+	// Email sender: Resend en producción, console log en desarrollo
+	var emailSender services.EmailSender
+	resendAPIKey := os.Getenv("RESEND_API_KEY")
+	resendFrom := os.Getenv("RESEND_FROM_EMAIL")
+	if resendAPIKey != "" && resendFrom != "" {
+		emailSender = services.NewResendEmailSender(resendAPIKey, resendFrom)
+		log.Println("Using Resend for password reset emails")
+	} else {
+		emailSender = services.NewConsoleEmailSender()
+		log.Println("Using console logger for password reset emails (dev mode)")
+	}
+
+	appBaseURL := os.Getenv("APP_BASE_URL")
+	if appBaseURL == "" {
+		appBaseURL = "http://localhost:8081"
+	}
+
+	authServiceWithReset := services.NewAuthServiceWithReset(userRepo, resetTokenRepo, emailSender, jwtSecret, appBaseURL)
 	themeService := services.NewThemeService(themeRepo, eventRepo)
 
 	// Google Drive backup configuration

--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -23,7 +23,8 @@ type AuthService struct {
 	jwtSecret       []byte
 	accessTokenTTL  time.Duration
 	refreshTokenTTL time.Duration
-	resetTokenTTL   time.Duration // e.g., 1 hour
+	resetTokenTTL   time.Duration // e.g., 15 minutes
+	baseURL         string        // URL base de la app para links en emails
 }
 
 // NewAuthService crea un nuevo servicio de autenticación
@@ -38,10 +39,11 @@ func NewAuthService(userRepo *repository.UserRepository, jwtSecret string) *Auth
 }
 
 // NewAuthServiceWithReset crea un nuevo AuthService con soporte para reset de password
-func NewAuthServiceWithReset(userRepo *repository.UserRepository, resetTokenRepo *repository.ResetTokenRepository, emailSender EmailSender, jwtSecret string) *AuthService {
+func NewAuthServiceWithReset(userRepo *repository.UserRepository, resetTokenRepo *repository.ResetTokenRepository, emailSender EmailSender, jwtSecret, baseURL string) *AuthService {
 	svc := NewAuthService(userRepo, jwtSecret)
 	svc.resetTokenRepo = resetTokenRepo
 	svc.emailSender = emailSender
+	svc.baseURL = baseURL
 	return svc
 }
 
@@ -255,9 +257,9 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 		return "", fmt.Errorf("failed to store reset token: %w", err)
 	}
 
-	// Construir URL de reset (el frontend reconstruye la URL completa)
-	// Aquí solo generamos el token raw; el frontend/army añade el token a la URL
-	if err := s.emailSender.SendPasswordReset(email, rawToken); err != nil {
+	// Construir URL completo de reset
+	resetURL := fmt.Sprintf("%s/reset-password?token=%s", s.baseURL, rawToken)
+	if err := s.emailSender.SendPasswordReset(email, resetURL); err != nil {
 		return "", fmt.Errorf("failed to send reset email: %w", err)
 	}
 

--- a/backend/internal/services/resend_email_sender.go
+++ b/backend/internal/services/resend_email_sender.go
@@ -1,0 +1,102 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ResendEmailSender implementa EmailSender usando la API de Resend
+// (https://resend.com) para envío real de emails en producción.
+type ResendEmailSender struct {
+	apiKey string
+	from   string
+	client *http.Client
+}
+
+// NewResendEmailSender crea un sender usando la API de Resend.
+// Si apiKey está vacío, retorna nil (debe chequearse antes de usar).
+func NewResendEmailSender(apiKey, from string) *ResendEmailSender {
+	if apiKey == "" {
+		return nil
+	}
+	return &ResendEmailSender{
+		apiKey: apiKey,
+		from:   from,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// SendPasswordReset envía el email de recuperación via Resend.
+func (r *ResendEmailSender) SendPasswordReset(email, resetURL string) error {
+	htmlBody := fmt.Sprintf(`
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Recuperar contraseña — EventHub</title>
+  <style>
+    body { font-family: 'Montserrat', sans-serif; background: #FFF5F7; padding: 40px; }
+    .container { max-width: 480px; margin: 0 auto; background: white; border-radius: 16px; padding: 32px; box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
+    h1 { color: #DB2777; font-size: 20px; margin-bottom: 16px; }
+    p { color: #4a3f44; line-height: 1.6; margin-bottom: 24px; }
+    .button { display: inline-block; background: #DB2777; color: white; text-decoration: none; padding: 14px 28px; border-radius: 999px; font-weight: 600; }
+    .footer { margin-top: 32px; font-size: 12px; color: #9ca3af; }
+    .link { word-break: break-all; color: #DB2777; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Recuperar contraseña</h1>
+    <p>Recibimos una solicitud para restablecer la contraseña de tu cuenta en EventHub.</p>
+    <p style="text-align:center;">
+      <a href="%s" class="button">Restablecer contraseña</a>
+    </p>
+    <p style="font-size:13px;">Este link expira en 15 minutos. Si no solicitaste el cambio, podés ignorar este email.</p>
+    <p style="font-size:13px;">Si el botón no funciona, copiá y pegá este link en tu navegador:<br>
+      <span class="link">%s</span>
+    </p>
+    <div class="footer">
+      EventHub — Plataforma de eventos interactivos<br>
+      Este es un email automático, no respondas a esta dirección.
+    </div>
+  </div>
+</body>
+</html>`, resetURL, resetURL)
+
+	payload := map[string]interface{}{
+		"from":    r.from,
+		"to":      []string{email},
+		"subject": "Recuperar contraseña — EventHub",
+		"html":    htmlBody,
+	}
+
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal email payload: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", "https://api.resend.com/emails", bytes.NewReader(jsonBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var errResp map[string]interface{}
+		_ = json.NewDecoder(resp.Body).Decode(&errResp)
+		return fmt.Errorf("resend API error (status %d): %v", resp.StatusCode, errResp)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What
Integrates Resend (https://resend.com) for real email delivery in password recovery flow.

## Changes
- **ResendEmailSender**: New implementation of EmailSender interface using Resend API
- **Auto-detection**: Uses Resend when `RESEND_API_KEY` and `RESEND_FROM_EMAIL` are set, falls back to console logging in dev
- **AuthService**: Now constructs full reset URL (`APP_BASE_URL/reset-password?token=...`)
- **Environment**: Added `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `APP_BASE_URL` to .env
- **Email template**: HTML email with EventHub branding, reset button, and fallback link

## Setup
1. Sign up at resend.com
2. Verify your domain/sender email
3. Add to .env:
   

## Fallback
If Resend is not configured, the system logs the reset URL to the server console (development mode).

## Stack
- Go 1.23, net/http, JSON API\n\n## Security
- No API keys hardcoded — all via environment variables\n- Resend API key never exposed to frontend