### PR TITLE
fix(backend): cast to numeric before ROUND in analytics query

### DIFF
--- a/backend/internal/handlers/analytics_handlers.go
+++ b/backend/internal/handlers/analytics_handlers.go
@@ -134,7 +134,7 @@ func (h *AnalyticsHandler) GetAnalyticsSummary(c *gin.Context) {
 			COALESCE(ps.total_players, 0) as total_players,
 			COALESCE(qs.quiz_started, 0) as quiz_started,
 			COALESCE(qs.quiz_completed, 0) as quiz_completed,
-			CASE WHEN COALESCE(qs.quiz_started, 0) > 0 THEN ROUND((qs.quiz_completed::float / qs.quiz_started) * 100, 2) ELSE 0 END as quiz_completion_rate,
+			CASE WHEN COALESCE(qs.quiz_started, 0) > 0 THEN ROUND(((qs.quiz_completed::float / qs.quiz_started) * 100)::numeric, 2) ELSE 0 END as quiz_completion_rate,
 			COALESCE(qs.avg_score, 0) as avg_score,
 			qs.min_score,
 			qs.max_score,


### PR DESCRIPTION
## Problem
Production PostgreSQL logs show repeated error:
```
ERROR:  function round(double precision, integer) does not exist
HINT:  No function matches the given name and argument types.
```

This broke the analytics/stats endpoint for event organizers.

## Root Cause
PostgreSQL does not support `ROUND(double_precision, integer)`. The expression:
```sql
ROUND((qs.quiz_completed::float / qs.quiz_started) * 100, 2)
```
returns `double precision`, but PostgreSQL's `ROUND` with two arguments requires `numeric`.

## Fix
Cast the division result to `::numeric` before `ROUND`:
```sql
ROUND(((qs.quiz_completed::float / qs.quiz_started) * 100)::numeric, 2)
```

## Verified
- `go build ./internal/handlers/...` passes
- Only one occurrence of this pattern in the entire codebase