### PR TITLE
fix(docker): pass Resend env vars and fix APP_BASE_URL protocol

### DIFF
--- a/backend/internal/services/auth_service.go
+++ b/backend/internal/services/auth_service.go
@@ -329,10 +329,10 @@ func HashPassword(password string) (string, error) {
 
 // Errores del servicio de auth
 var (
-	ErrDuplicateEmail           = errors.New("email already exists")
-	ErrInvalidCredentials       = errors.New("invalid credentials")
-	ErrInvalidToken             = errors.New("invalid or expired token")
-	ErrInvalidRefreshToken      = errors.New("invalid refresh token")
+	ErrDuplicateEmail             = errors.New("email already exists")
+	ErrInvalidCredentials         = errors.New("invalid credentials")
+	ErrInvalidToken               = errors.New("invalid or expired token")
+	ErrInvalidRefreshToken        = errors.New("invalid refresh token")
 	ErrPasswordResetNotConfigured = errors.New("password reset not configured")
-	ErrInvalidResetToken        = errors.New("invalid or expired reset token")
+	ErrInvalidResetToken          = errors.New("invalid or expired reset token")
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:8081/api/admin/drive/callback}
       DRIVE_ENCRYPTION_KEY: ${DRIVE_ENCRYPTION_KEY:-}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM_EMAIL: ${RESEND_FROM_EMAIL:-}
+      APP_BASE_URL: ${APP_BASE_URL:-http://localhost:8081}
     volumes:
       - uploads_data:/app/uploads
     networks:


### PR DESCRIPTION
## Problem
Password recovery emails were broken in two ways:
1. **docker-compose.yml** didn't pass `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, or `APP_BASE_URL` to the backend container, causing it to always fall back to ConsoleEmailSender (dev mode) even when Resend was configured.
2. `APP_BASE_URL=https://localhost:8081` in .env generated `https://` links in emails, but localhost has no SSL certificate, so the links were unreachable.

## Fix
- Added the three missing environment variables to the backend service in docker-compose.yml
- Corrected APP_BASE_URL from `https://` to `http://` in .env (localhost = no SSL)

## Verified
- Backend now logs `Using Resend for password reset emails` when configured
- Generated reset URLs are now `http://localhost:8081/reset-password?token=...` (reachable in local dev)
- End-to-end test: register → forgot-password → reset-password → login ✅