### PR TITLE
feat(postcards): make sender name optional, remove 'Anónimo' fallback

### DIFF
--- a/frontend/src/features/postcards/components/FramedPhoto.tsx
+++ b/frontend/src/features/postcards/components/FramedPhoto.tsx
@@ -57,7 +57,7 @@ export function FramedPhoto({
       <div
         className="relative bg-white px-3 pt-3 pb-4 shadow-md overflow-hidden"
         role={isVideo ? 'group' : 'img'}
-        aria-label={isVideo ? `Video de ${caption}` : `Foto de ${caption}`}
+        aria-label={isVideo ? (caption ? `Video de ${caption}` : 'Video') : (caption ? `Foto de ${caption}` : 'Foto')}
       >
         <div className={`relative w-full ${aspectRatio} overflow-hidden bg-gray-100`}>
           {isVideo ? (
@@ -70,7 +70,7 @@ export function FramedPhoto({
           ) : (
             <img
               src={imageError ? fallbackSrc : src}
-              alt={`Foto de ${caption}`}
+              alt={caption ? `Foto de ${caption}` : 'Foto'}
               className={`w-full h-full ${imageError ? 'object-contain p-4 opacity-50' : 'object-cover'}`}
               loading="lazy"
               onError={() => setImageError(true)}
@@ -79,23 +79,25 @@ export function FramedPhoto({
         </div>
       </div>
 
-      <div className="mt-2 text-center">
-        <p
-          className="text-sm font-medium truncate max-w-[200px]"
-          style={{ color: textColor }}
-          title={caption}
-        >
-          {caption}
-        </p>
-        {isVideo && (
+      {caption && (
+        <div className="mt-2 text-center">
           <p
-            className="text-[10px] uppercase tracking-wider mt-0.5"
-            style={{ color: `${textColor}80` }}
+            className="text-sm font-medium truncate max-w-[200px]"
+            style={{ color: textColor }}
+            title={caption}
           >
-            video
+            {caption}
           </p>
-        )}
-      </div>
+          {isVideo && (
+            <p
+              className="text-[10px] uppercase tracking-wider mt-0.5"
+              style={{ color: `${textColor}80` }}
+            >
+              video
+            </p>
+          )}
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/frontend/src/features/postcards/components/PostcardCard.tsx
+++ b/frontend/src/features/postcards/components/PostcardCard.tsx
@@ -74,7 +74,7 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
           onKeyDown={handleKeyDown}
           role="button"
           tabIndex={0}
-          aria-label={`Abrir postal de ${presentation.captionName}`}
+          aria-label={presentation.captionName ? `Abrir postal de ${presentation.captionName}` : 'Abrir postal'}
           layout
           initial={{ opacity: 0, scale: 0.8, y: 20 }}
           animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -85,7 +85,7 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
               src={postcard.image_path}
               isVideo={isVideo}
               orientation={orientation}
-              caption={presentation.captionName}
+              caption={presentation.captionName || ''}
               theme={theme}
               thumbnailPath={postcard.thumbnail_path}
               durationMs={postcard.media_duration_ms}
@@ -122,7 +122,7 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
         onKeyDown={handleKeyDown}
         role="button"
         tabIndex={0}
-        aria-label={`Abrir postal de ${postcard.player_name}`}
+          aria-label={postcard.player_name ? `Abrir postal de ${postcard.player_name}` : 'Abrir postal'}
         layout
         initial={{ opacity: 0, scale: 0.8, y: 20 }}
         animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -141,7 +141,7 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
                 {/* Video thumbnail con play overlay */}
                 <img
                   src={imageError ? videoFallback : (postcard.thumbnail_path || videoFallback)}
-                  alt={`Video de ${postcard.player_name}`}
+                  alt={postcard.player_name ? `Video de ${postcard.player_name}` : 'Video'}
                   className={`absolute inset-0 w-full h-full ${imageError ? 'object-contain p-4 opacity-50' : 'object-cover'}`}
                   loading="lazy"
                   onError={() => setImageError(true)}
@@ -180,7 +180,7 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
             ) : (
               <img
                 src={imageError ? imageFallback : postcard.image_path}
-                alt={`Postal de ${postcard.player_name}`}
+                alt={postcard.player_name ? `Postal de ${postcard.player_name}` : 'Postal'}
                 className={`absolute inset-0 w-full h-full ${imageError ? 'object-contain p-4 opacity-50' : 'object-cover'}`}
                 loading="lazy"
                 onError={() => setImageError(true)}
@@ -219,15 +219,17 @@ export function PostcardCard({ postcard, onSelect, eventLogoUrl, theme }: Postca
               </p>
             </div>
 
-            {/* From: nombre */}
-            <div className="relative z-10 mt-2 pt-2" style={{ borderTopColor: `${primaryColor}30`, borderTopWidth: '1px' }}>
-              <p className="text-[10px] flex items-center gap-1" style={{ color: `${textColor}80` }}>
-                <span className="text-sm">{postcard.player_avatar}</span>
-                <span className="font-medium" style={{ color: primaryColor }}>
-                  {postcard.player_name}
-                </span>
-              </p>
-            </div>
+            {/* From: nombre — solo si hay nombre */}
+            {postcard.player_name && (
+              <div className="relative z-10 mt-2 pt-2" style={{ borderTopColor: `${primaryColor}30`, borderTopWidth: '1px' }}>
+                <p className="text-[10px] flex items-center gap-1" style={{ color: `${textColor}80` }}>
+                  <span className="text-sm">{postcard.player_avatar}</span>
+                  <span className="font-medium" style={{ color: primaryColor }}>
+                    {postcard.player_name}
+                  </span>
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </motion.div>

--- a/frontend/src/features/postcards/lib/postcardPresentation.test.ts
+++ b/frontend/src/features/postcards/lib/postcardPresentation.test.ts
@@ -95,7 +95,7 @@ describe('getPostcardPresentation', () => {
     expect(result.captionName).toBe('Player Name');
   });
 
-  it('falls back to player_name when sender_name is empty string', () => {
+  it('keeps empty sender_name as captionName (no fallback to player_name)', () => {
     const postcard = makePostcard({
       message: '',
       sender_name: '',
@@ -103,7 +103,7 @@ describe('getPostcardPresentation', () => {
     });
     const result = getPostcardPresentation(postcard);
 
-    // Empty string is falsy in JS, so || falls back to player_name
-    expect(result.captionName).toBe('Player Name');
+    // Empty string is intentionally kept so the UI can hide the caption
+    expect(result.captionName).toBe('');
   });
 });

--- a/frontend/src/features/postcards/lib/postcardPresentation.ts
+++ b/frontend/src/features/postcards/lib/postcardPresentation.ts
@@ -20,6 +20,6 @@ export function getPostcardPresentation(postcard: Postcard): PostcardPresentatio
   return {
     mode: hasMessage ? 'postcard' : 'photo',
     hasMessage,
-    captionName: postcard.sender_name || postcard.player_name,
+    captionName: postcard.sender_name !== undefined ? postcard.sender_name : postcard.player_name,
   };
 }

--- a/frontend/src/features/postcards/pages/CorkboardPage.tsx
+++ b/frontend/src/features/postcards/pages/CorkboardPage.tsx
@@ -64,8 +64,8 @@ export function CorkboardPage() {
   }, [searchParams]);
 
   const handleAddPostcard = async (image: File, message: string, senderName?: string) => {
-    // Default sender name if not provided
-    const name = senderName?.trim() || 'Anónimo';
+    // Pass name as-is; empty names are allowed for quick party uploads
+    const name = senderName?.trim() || '';
     await createPostcard(image, message, name);
     if (!hasRegisteredPlayer && senderName?.trim()) {
       setHasRegisteredPlayer(true);
@@ -297,7 +297,7 @@ export function CorkboardPage() {
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
         onSubmit={handleAddPostcard}
-        requireSenderName={!hasRegisteredPlayer}
+        requireSenderName={false}
       />
 
       {!isAddOpen && (


### PR DESCRIPTION
## Summary
Allows guests to upload photos without typing their name — ideal for high-energy party moments (dancing, etc.).

## Changes
- Removed hardcoded `'Anónimo'` fallback in `CorkboardPage`
- Set `requireSenderName=false` so unregistered guests can upload friction-free
- Updated `postcardPresentation.ts` to keep empty `sender_name` instead of falling back to `player_name`
- Conditionally render caption and "From:" label in `PostcardCard` and `FramedPhoto` only when name exists
- Updated test expectation for empty `sender_name` behavior

## Why
Many guests at parties don't have time or patience to fill forms. This removes all friction: snap a photo, hit upload, done. No names, no "Anónimo" labels, just pure photos on the corkboard.

## Files changed
- `frontend/src/features/postcards/pages/CorkboardPage.tsx`
- `frontend/src/features/postcards/lib/postcardPresentation.ts`
- `frontend/src/features/postcards/lib/postcardPresentation.test.ts`
- `frontend/src/features/postcards/components/PostcardCard.tsx`
- `frontend/src/features/postcards/components/FramedPhoto.tsx`