### PR TITLE
fix(postcards): allow empty sender name end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /frontend/node_modules/
 /frontend/dist/
 /frontend/dist-ssr/
+/frontend/dev-dist/
 /frontend/*.local
 /frontend/.env
 /frontend/.env.local

--- a/backend/internal/handlers/handlers.go
+++ b/backend/internal/handlers/handlers.go
@@ -816,9 +816,9 @@ func (h *Handler) CreatePostcard(c *gin.Context) {
 		rawName := truncateMessage(c.Request.FormValue("name"), 255)
 		rawAvatar := truncateMessage(c.Request.FormValue("avatar"), 10)
 
+		// Allow empty name for quick party uploads (photo-only, no name required)
 		if rawName == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Player ID or name required"})
-			return
+			rawName = ""
 		}
 
 		// Avatar por defecto si no se proporciona
@@ -853,11 +853,9 @@ func (h *Handler) CreatePostcard(c *gin.Context) {
 	message := truncateMessage(c.Request.FormValue("message"), 500)
 
 	// sender_name opcional: permite que alguien use el celular de otro
+	// Empty string is intentional (guest didn't type a name) and is preserved
 	rawSenderName := truncateMessage(c.Request.FormValue("sender_name"), 255)
-	var senderName *string
-	if rawSenderName != "" {
-		senderName = &rawSenderName
-	}
+	senderName := &rawSenderName
 
 	rotation := (rand.Float64() * 60) - 30 // -30 a 30
 

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -34,7 +34,7 @@ type RankingEntry struct {
 
 // CreatePlayerRequest representa el body de creación de jugador
 type CreatePlayerRequest struct {
-	Name   string `json:"name" binding:"required"`
+	Name   string `json:"name"`
 	Avatar string `json:"avatar"`
 }
 

--- a/backend/internal/repository/postcard_repository.go
+++ b/backend/internal/repository/postcard_repository.go
@@ -92,7 +92,7 @@ const publicPostcardCols = `
 	p.event_id::text,
 	p.player_id::text,
 	p.sender_name,
-	COALESCE(p.sender_name, pl.name, 'Invitado') AS player_name,
+	COALESCE(NULLIF(p.sender_name, ''), pl.name, 'Invitado') AS player_name,
 	CASE WHEN p.is_secret = TRUE THEN '🎁' ELSE COALESCE(pl.avatar, '👤') END AS player_avatar,
 	p.image_path, p.message, p.rotation, p.is_secret, p.revealed_at, p.created_at,
 	p.media_type, p.thumbnail_path, p.media_duration_ms

--- a/frontend/src/features/event-admin/components/PostcardsPreviewGrid.tsx
+++ b/frontend/src/features/event-admin/components/PostcardsPreviewGrid.tsx
@@ -42,7 +42,7 @@ interface PostcardCardProps {
 
 function PostcardCard({ postcard, theme }: PostcardCardProps) {
   const isNew = isNewerThan24Hours(postcard.created_at);
-  const displayName = postcard.sender_name || 'Anónimo';
+  const displayName = postcard.sender_name || undefined;
   const imagePath = postcard.thumbnail_path || postcard.image_path;
   const [imageError, setImageError] = useState(false);
 
@@ -65,14 +65,14 @@ function PostcardCard({ postcard, theme }: PostcardCardProps) {
           {postcard.media_type === 'video' ? (
             <img
               src={imageError ? VIDEO_PLACEHOLDER : (postcard.thumbnail_path || VIDEO_PLACEHOLDER)}
-              alt={displayName}
+              alt={displayName || 'Postal'}
               className="w-full h-full object-cover"
               onError={() => setImageError(true)}
             />
           ) : imagePath ? (
             <img
               src={imagePath}
-              alt={displayName}
+              alt={displayName || 'Postal'}
               className="w-full h-full object-cover"
               onError={() => setImageError(true)}
             />
@@ -95,12 +95,14 @@ function PostcardCard({ postcard, theme }: PostcardCardProps) {
 
         {/* Info */}
         <div className="p-2">
-          <div className="flex items-center gap-1 mb-1">
-            <span className="text-lg">🎁</span>
-            <span className="text-xs font-medium truncate" style={{ color: theme.textColor }}>
-              {displayName}
-            </span>
-          </div>
+          {displayName && (
+            <div className="flex items-center gap-1 mb-1">
+              <span className="text-lg">🎁</span>
+              <span className="text-xs font-medium truncate" style={{ color: theme.textColor }}>
+                {displayName}
+              </span>
+            </div>
+          )}
           <div className="flex items-center gap-1 text-xs" style={{ color: `${theme.textColor}60` }}>
             <Clock className="w-3 h-3" />
             <span>{formatRelativeTime(postcard.created_at)}</span>

--- a/frontend/src/features/event-admin/components/RevealButton.tsx
+++ b/frontend/src/features/event-admin/components/RevealButton.tsx
@@ -180,7 +180,7 @@ export function RevealButton({ slug, theme }: RevealButtonProps) {
                     >
                       <span className="text-lg">🎁</span>
                       <span className="text-sm font-medium" style={{ color: theme.textColor }}>
-                        {postcard.sender_name || 'Anónimo'}
+                        {postcard.sender_name || 'Sin nombre'}
                       </span>
                     </div>
                   ))}

--- a/frontend/src/shared/lib/api.ts
+++ b/frontend/src/shared/lib/api.ts
@@ -594,9 +594,11 @@ class ApiClient {
     }
 
     // Si sigue sin haber player, intentar con senderName como fallback
-    if (!effectivePlayerId && options?.senderName) {
+    // Empty string is allowed (guest didn't type a name), backend auto-creates a generic player
+    if (!effectivePlayerId && options?.senderName !== undefined) {
+      const playerName = options.senderName?.trim() || '';
       const player = await this.createPlayerScoped(eventSlug, {
-        name: options.senderName,
+        name: playerName,
         avatar: '📸',
       });
       effectivePlayerId = player.id;


### PR DESCRIPTION
## Description

Completes the remaining fixes from PR #92 that weren't included in the squash merge. Makes the 'optional sender name' feature work end-to-end correctly.

## Changes

### Backend
- Remove `binding:"required"` from `CreatePlayerRequest.Name` so empty names are accepted
- Allow empty `rawName` in inline player registration (was returning 400)
- Always set `senderName = &rawSenderName` (preserve empty string instead of nil)
- Use `NULLIF(p.sender_name, '')` in COALESCE so empty string → empty `player_name`

### Frontend
- `api.ts`: Check `options?.senderName !== undefined` instead of truthy, so empty string is passed through
- `PostcardsPreviewGrid.tsx`: Hide name block when `sender_name` is falsy (no 'Anónimo' fallback)  
- `RevealButton.tsx`: Show 'Sin nombre' instead of 'Anónimo'

### Config
- `.gitignore`: Add `frontend/dev-dist/`

## Verification

E2E tested with playwright-cli:
1. Navigate to corkboard anonymously
2. Upload photo without entering sender name
3. Postcard appears with caption: empty (no 'Invitado', no 'Anónimo')
4. aria-label: `"Abrir postal"` (not `"Abrir postal de Invitado"`)
5. DB confirms: `sender_name = ''`, `player_name = ''`