### PR TITLE
feat(postcards): separate camera and gallery buttons for photo mode

### DIFF
--- a/frontend/src/features/postcards/components/AddPostcardSheet.tsx
+++ b/frontend/src/features/postcards/components/AddPostcardSheet.tsx
@@ -39,8 +39,9 @@ export function AddPostcardSheet({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // File input ref
+  // File input refs
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const galleryInputRef = useRef<HTMLInputElement>(null);
 
   // Video recording refs
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -456,11 +457,19 @@ export function AddPostcardSheet({
 
               {/* Zona de foto/video */}
               <div className="relative">
-                <input
+<input
                   ref={fileInputRef}
                   type="file"
-                  accept={mediaMode === 'video' ? 'video/*' : 'image/*'}
-                  capture={mediaMode === 'photo' ? 'user' : undefined}
+                  accept="image/*"
+                  capture="user"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                {/* Separate input for gallery selection (no capture attribute) */}
+                <input
+                  ref={galleryInputRef}
+                  type="file"
+                  accept="image/*"
                   onChange={handleFileChange}
                   className="hidden"
                 />
@@ -501,20 +510,34 @@ export function AddPostcardSheet({
                   </div>
                 ) : (
                   <>
-                    {/* Modo foto */}
+{/* Modo foto */}
                     {mediaMode === 'photo' ? (
-                      <motion.button
-                        whileHover={{ scale: 1.01 }}
-                        whileTap={{ scale: 0.98 }}
-                        onClick={() => fileInputRef.current?.click()}
-                        className="w-full aspect-[4/3] rounded-xl border-2 border-dashed flex flex-col items-center justify-center gap-3 cursor-pointer transition-colors"
-                        style={{ borderColor: `${colors.primary}40`, backgroundColor: `${colors.primary}10` }}
-                      >
-                        <span className="text-4xl">📸</span>
-                        <span className="text-sm font-medium" style={{ color: `${colors.text}80` }}>
-                          Tomar foto / Elegir imagen
-                        </span>
-                      </motion.button>
+                      <div className="flex gap-3">
+                        <motion.button
+                          whileHover={{ scale: 1.01 }}
+                          whileTap={{ scale: 0.98 }}
+                          onClick={() => fileInputRef.current?.click()}
+                          className="flex-1 aspect-[4/3] rounded-xl border-2 border-dashed flex flex-col items-center justify-center gap-2 cursor-pointer transition-colors"
+                          style={{ borderColor: `${colors.primary}40`, backgroundColor: `${colors.primary}10` }}
+                        >
+                          <span className="text-3xl">📸</span>
+                          <span className="text-xs font-medium" style={{ color: `${colors.text}80` }}>
+                            Tomar foto
+                          </span>
+                        </motion.button>
+                        <motion.button
+                          whileHover={{ scale: 1.01 }}
+                          whileTap={{ scale: 0.98 }}
+                          onClick={() => galleryInputRef.current?.click()}
+                          className="flex-1 aspect-[4/3] rounded-xl border-2 border-dashed flex flex-col items-center justify-center gap-2 cursor-pointer transition-colors"
+                          style={{ borderColor: `${colors.primary}40`, backgroundColor: `${colors.primary}10` }}
+                        >
+                          <span className="text-3xl">🖼️</span>
+                          <span className="text-xs font-medium" style={{ color: `${colors.text}80` }}>
+                            Galería
+                          </span>
+                        </motion.button>
+                      </div>
                     ) : (
                       /* Modo video con cámara en vivo */
                       <div className="relative w-full aspect-[4/3] rounded-xl overflow-hidden bg-gray-900">


### PR DESCRIPTION
## Description

Adds two distinct buttons for photo selection instead of one combined option:

- **📸 Tomar foto**: Opens device camera directly via  attribute
- **🖼️ Galería**: Opens native file picker for selecting from photo library

This matches the UX pattern already used in video mode, which has both live camera and file upload options.

## Changes

- Add  alongside  
- Two hidden file inputs: camera () and gallery (no capture)
- Side-by-side buttons in photo mode replacing the single combined button
- Both buttons share the same  callback

## Verification

Manual E2E test needed — open corkboard → add postcard → confirm two buttons appear